### PR TITLE
Remove universal wheel setting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,6 @@ current_version = 0.0.2
 commit = True
 tag = True
 
-[bdist_wheel]
-universal = 1
-
 [metadata]
 description-file = README.md
 license_file = LICENSE


### PR DESCRIPTION
Python 2 is not supported, so this setting is not correct. It is not required for packaging.