### PR TITLE
Remove dynamic Storage detection from form.FileField and Widget classes

### DIFF
--- a/s3_file_field/forms.py
+++ b/s3_file_field/forms.py
@@ -4,7 +4,6 @@ from django.contrib.admin.widgets import AdminFileWidget
 from django.core.signing import BadSignature, Signer
 from django.forms import FileField, ValidationError, Widget
 
-from .constants import S3FF_STORAGE_PROVIDER, StorageProvider
 from .widgets import S3AdminFileInput, S3FakeFile, S3FileInput
 
 
@@ -14,24 +13,23 @@ class S3FormFileField(FileField):
     widget = S3FileInput
 
     def __init__(self, widget: Optional[Union[Type[Widget], Widget]] = None, **kwargs):
-        if S3FF_STORAGE_PROVIDER != StorageProvider.UNSUPPORTED:
-            # For form fields created under django.contrib.admin.options.BaseModelAdmin, any form
-            # field representing a model.FileField subclass will request a
-            # django.contrib.admin.widgets.AdminFileWidget as a 'widget' parameter override
-            # Custom subclasses of BaseModelAdmin can use formfield_overrides to change
-            # the default widget for their forms, but this is burdensome
-            # So, instead change any requests for an AdminFileWidget to a S3AdminFileInput
-            if widget:
-                if isinstance(widget, type):
-                    # widget is a type
-                    if issubclass(widget, AdminFileWidget):
-                        widget = S3AdminFileInput
-                else:
-                    # widget is an instance
-                    if isinstance(widget, AdminFileWidget):
-                        # We can't easily re-instantiate the Widget, since we need its initial
-                        # parameters, so attempt to rebuild the constructor parameters
-                        widget = S3AdminFileInput(attrs={'type': widget.input_type, **widget.attrs})
+        # For form fields created under django.contrib.admin.options.BaseModelAdmin, any form
+        # field representing a model.FileField subclass will request a
+        # django.contrib.admin.widgets.AdminFileWidget as a 'widget' parameter override
+        # Custom subclasses of BaseModelAdmin can use formfield_overrides to change
+        # the default widget for their forms, but this is burdensome
+        # So, instead change any requests for an AdminFileWidget to a S3AdminFileInput
+        if widget:
+            if isinstance(widget, type):
+                # widget is a type
+                if issubclass(widget, AdminFileWidget):
+                    widget = S3AdminFileInput
+            else:
+                # widget is an instance
+                if isinstance(widget, AdminFileWidget):
+                    # We can't easily re-instantiate the Widget, since we need its initial
+                    # parameters, so attempt to rebuild the constructor parameters
+                    widget = S3AdminFileInput(attrs={'type': widget.input_type, **widget.attrs})
 
         super().__init__(widget=widget, **kwargs)
 

--- a/s3_file_field/widgets.py
+++ b/s3_file_field/widgets.py
@@ -6,8 +6,6 @@ from typing import Any, Dict, Iterable, Mapping
 from django.forms import ClearableFileInput
 from django.urls import reverse
 
-from .constants import S3FF_STORAGE_PROVIDER, StorageProvider
-
 
 @functools.lru_cache(maxsize=1)
 def get_base_url() -> str:
@@ -46,15 +44,10 @@ class S3FakeFile:
 class S3FileInput(ClearableFileInput):
     """widget to render the S3 File Input."""
 
+    template_name = 'joist/s3fileinput.html'
+
     class Media:
         js = ['joist/joist.js']
-
-    @property
-    def template_name(self):
-        if S3FF_STORAGE_PROVIDER == StorageProvider.UNSUPPORTED:
-            return 'django/forms/widgets/file.html'
-        else:
-            return 'joist/s3fileinput.html'
 
     def get_context(self, name: str, value: str, attrs):
         context = super().get_context(name, value, attrs)
@@ -78,9 +71,4 @@ class S3FileInput(ClearableFileInput):
 class S3AdminFileInput(S3FileInput):
     """widget used by the admin page."""
 
-    @property
-    def template_name(self):
-        if S3FF_STORAGE_PROVIDER == StorageProvider.UNSUPPORTED:
-            return 'admin/widgets/clearable_file_input.html'
-        else:
-            return 'joist/s3adminfileinput.html'
+    template_name = 'joist/s3adminfileinput.html'


### PR DESCRIPTION
Ultimately, any dynamic `Storage` detection should be based on the particular `Storage` used by an `S3FieldField` instance, not Django's global media `Storage`.

`form.FileField` and `Widget` instances do not have a reference to the `S3FieldFild` which they support, so they should never attempt to detect the current `Storage` or alter their behavior accordingly. Instead, the use of a `form.FileField` vs. `S3FormFileField` should be determined exclusively by `S3FileField.formfield` or by direct instantiation from downstream projects.

Future work will attempt to make `S3FileField.formfield` detect the current `Storage`.