### PR TITLE
Improve supported storage detection

### DIFF
--- a/s3_file_field/constants.py
+++ b/s3_file_field/constants.py
@@ -4,7 +4,7 @@ from typing import Optional
 from urllib.parse import urlsplit, urlunsplit
 
 from django.conf import settings
-from django.utils.module_loading import import_string
+from django.core.files.storage import Storage, default_storage
 
 
 class StorageProvider(enum.Enum):
@@ -13,12 +13,14 @@ class StorageProvider(enum.Enum):
     UNSUPPORTED = enum.auto()
 
 
-def _get_storage_provider() -> StorageProvider:
-    _storage_class = import_string(settings.DEFAULT_FILE_STORAGE)
+def _get_storage_provider(storage: Storage = None) -> StorageProvider:
+    if storage is None:
+        storage = default_storage
+
     try:
         from storages.backends.s3boto3 import S3Boto3Storage
 
-        if _storage_class == S3Boto3Storage or issubclass(_storage_class, S3Boto3Storage):
+        if isinstance(storage, S3Boto3Storage):
             return StorageProvider.AWS
     except ImportError:
         pass
@@ -26,7 +28,7 @@ def _get_storage_provider() -> StorageProvider:
     try:
         from minio_storage.storage import MinioMediaStorage
 
-        if _storage_class == MinioMediaStorage or issubclass(_storage_class, MinioMediaStorage):
+        if isinstance(storage, MinioMediaStorage):
             return StorageProvider.MINIO
     except ImportError:
         pass

--- a/s3_file_field/constants.py
+++ b/s3_file_field/constants.py
@@ -36,6 +36,10 @@ def _get_storage_provider(storage: Storage = None) -> StorageProvider:
     return StorageProvider.UNSUPPORTED
 
 
+def supported_storage(storage: Storage = None) -> bool:
+    return _get_storage_provider(storage) != StorageProvider.UNSUPPORTED
+
+
 # internal settings
 S3FF_UPLOAD_DURATION = 60 * 60 * 12
 # TODO move this here

--- a/s3_file_field/fields.py
+++ b/s3_file_field/fields.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 from django.db.models.fields.files import FieldFile, FileField
 from django.forms import Field as FormField
 
-from .constants import S3FF_STORAGE_PROVIDER, StorageProvider
+from .constants import supported_storage
 from .forms import S3FormFileField
 from .widgets import S3FakeFile
 
@@ -59,7 +59,7 @@ class S3FileField(FileField):
 
         This is an instance of "form_class", with a widget of "widget".
         """
-        if S3FF_STORAGE_PROVIDER != StorageProvider.UNSUPPORTED:
+        if supported_storage():
             # Use S3FormFileField as a default, instead of forms.FileField from the superclass
             kwargs.setdefault('form_class', S3FormFileField)
         return super().formfield(**kwargs)

--- a/s3_file_field/fields.py
+++ b/s3_file_field/fields.py
@@ -59,7 +59,7 @@ class S3FileField(FileField):
 
         This is an instance of "form_class", with a widget of "widget".
         """
-        if supported_storage():
+        if supported_storage(self.storage):
             # Use S3FormFileField as a default, instead of forms.FileField from the superclass
             kwargs.setdefault('form_class', S3FormFileField)
         return super().formfield(**kwargs)


### PR DESCRIPTION
* Allow `_get_storage_provider` to check against non-media Storages too
* Add a `constants.supported_storage` utility function
* Use the `S3FileField`'s own storage instance, rather than the media storage