### PR TITLE
Remove deprecated providing_args argument to Signal declarations

### DIFF
--- a/s3_file_field/signals.py
+++ b/s3_file_field/signals.py
@@ -1,6 +1,4 @@
 import django.dispatch
 
-s3_file_field_upload_prepare = django.dispatch.Signal(providing_args=['name', 'object_key'])
-s3_file_field_upload_finalize = django.dispatch.Signal(
-    providing_args=['name', 'object_key', 'status']
-)
+s3_file_field_upload_prepare = django.dispatch.Signal()
+s3_file_field_upload_finalize = django.dispatch.Signal()


### PR DESCRIPTION
This is deprecated by Django 3.1, and was never used or enforced by earlier versions.