### PR TITLE
Multipart client

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -569,6 +569,14 @@
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
       "dev": true
     },
+    "axios": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2244,6 +2252,11 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
+    },
+    "follow-redirects": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -46,6 +46,7 @@
     "@types/js-cookie": "^2.2.6",
     "@types/node": "^14.0.13",
     "aws-sdk": "^2.693.0",
+    "axios": "^0.20.0",
     "js-cookie": "^2.2.1"
   }
 }

--- a/client/src/S3FileInput.ts
+++ b/client/src/S3FileInput.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_BASE_URL, EVENT_UPLOAD_COMPLETE, EVENT_UPLOAD_STARTED } from "./constants";
-import { uploadFile, UploadResult } from "./uploader";
+import { uploadFile, UploadResult } from "./client";
 
 function cssClass(clazz: string): string {
   return `s3fileinput-${clazz}`;

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -1,0 +1,122 @@
+import axios from 'axios';
+
+// Possible upload states
+export declare type EProgressState = 'initial' | 'uploading' | 'preparing' | 'finishing' | 'done' | 'aborted';
+// Arguments to uploadFile()
+export interface UploadOptions {
+  baseUrl: string;
+  onProgress(progress: { percentage: number; loaded: number; total: number; state: EProgressState }): void;
+  abortSignal?(onAbort: () => void): void;
+}
+// Description of a part from initializeUpload()
+interface PartInfo {
+  part_number: number;
+  size: number;
+  upload_url: string;
+}
+// Description of the upload from initializeUpload()
+interface MultipartInfo {
+  object_key: string;
+  upload_id: string;
+  parts: PartInfo[];
+}
+// Description of a part which has been uploaded by uploadPart()
+interface UploadedPart {
+  part_number: number;
+  size: number;
+  etag: string;
+}
+// Return value from uploadFile()
+export interface UploadResult {
+  name: string;
+  value: string;
+  state: 'aborted' | 'successful' | 'error';
+  msg: string;
+}
+
+/**
+ * Initializes an upload.
+ *
+ * @param file the file to upload
+ * @param options the upload options
+ * @returns MultipartResponse
+ */
+async function initializeUpload(file: File, options: UploadOptions): Promise<MultipartInfo> {
+  const response = await axios.post(`${options.baseUrl}/upload-initialize/`, {'file_name': file.name, 'file_size': file.size});
+  return response.data;
+}
+
+/**
+ * Uploads a part directly to an object store.
+ *
+ * @param url the URL to upload the part to
+ * @param chunk the data to upload
+ * @returns UploadedPart
+ */
+async function uploadPart(chunk: ArrayBuffer, part: PartInfo): Promise<UploadedPart> {
+  const response = await axios.put(part.upload_url, chunk);
+  const etag = response.headers['etag'];
+  return {
+    part_number: part.part_number,
+    size: part.size,
+    etag,
+  }
+}
+
+/**
+ * Uploads all the parts in a file directly to an object store in parallel.
+ *
+ * @param file the file to upload
+ * @param parts the list of parts describing how to break up the file
+ * @returns UploadedPart[]
+ */
+async function uploadParts(file: File, parts: PartInfo[]): Promise<UploadedPart[]> {
+  const buffer = await file.arrayBuffer();
+  // indices track where in the buffer each part begins
+  let index = 0;
+  const indices: number[] = [];
+  for (const part of parts) {
+    indices.push(index);
+    index += part.size;
+  }
+  // upload each part of the buffer in parallel using the calculated indices
+  return await Promise.all(parts.map(async (part, i) => {
+    const chunk = buffer.slice(indices[i], indices[i] + part.size);
+    return await uploadPart(chunk, part);
+  }));
+}
+
+/**
+ * Finalizes an upload.
+ *
+ * @param multipartInfo the information describing the multipart upload
+ * @param parts the parts that were uploaded
+ * @returns UploadResult
+ */
+async function finalizeUpload(multipartInfo: MultipartInfo, parts: UploadedPart[], options: UploadOptions): Promise<undefined> {
+  await axios.post(`${options.baseUrl}/upload-finalize/`, {
+    object_key: multipartInfo.object_key,
+    upload_id: multipartInfo.upload_id,
+    parts: parts,
+  });
+  return;
+}
+
+/**
+ * Uploads a file using multipart upload.
+ *
+ * @param file the file to upload
+ * @param options the upload options
+ */
+export async function uploadFile(file: File, options: UploadOptions): Promise<UploadResult> {
+  // TODO most options are unused, but maintained for reverse compatibility
+  const multipartInfo = await initializeUpload(file, options);
+  const parts = await uploadParts(file, multipartInfo.parts);
+  await finalizeUpload(multipartInfo, parts, options);
+  return {
+    name: file.name,
+    value: '',
+    state: 'successful',
+    msg: '',
+  }
+}


### PR DESCRIPTION
Adds `client.ts`, which for now is just a drop-in replacement for `uploader.ts` that does multipart upload instead of using the AWS client. The method signatures and exports are the same, although some arguments are now ignored. 

For posterity, the invocation to update `joist.js` is to run `python setup.py jsdeps`. 