### PR TITLE
Upload to field storage

### DIFF
--- a/client/src/S3FileInput.ts
+++ b/client/src/S3FileInput.ts
@@ -42,6 +42,7 @@ export default class S3FileInput {
 
   private readonly baseUrl: string;
   private readonly autoUpload: boolean;
+  private readonly fieldId: string;
 
   constructor(input: HTMLInputElement, options: Partial<S3FileInputOptions> = {}) {
     this.input = input;
@@ -52,6 +53,7 @@ export default class S3FileInput {
       options.autoUpload != null
         ? options.autoUpload
         : this.input.dataset.autoUpload != null;
+    this.fieldId = this.input.dataset?.fieldId || ''; // TODO this should error out
 
     this.node = input.ownerDocument!.createElement("div");
     this.node.classList.add(cssClass("wrapper"));
@@ -148,7 +150,7 @@ export default class S3FileInput {
     });
     this.input.dispatchEvent(event);
 
-    return uploadFile(file, {
+    return uploadFile(file, this.fieldId, {
       baseUrl: this.baseUrl,
       onProgress: p => {
         progress.dataset.state = p.state;

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -41,8 +41,8 @@ export interface UploadResult {
  * @param options the upload options
  * @returns MultipartResponse
  */
-async function initializeUpload(file: File, options: UploadOptions): Promise<MultipartInfo> {
-  const response = await axios.post(`${options.baseUrl}/upload-initialize/`, {'file_name': file.name, 'file_size': file.size});
+async function initializeUpload(file: File, fieldId: string, options: UploadOptions): Promise<MultipartInfo> {
+  const response = await axios.post(`${options.baseUrl}/upload-initialize/`, {'field_id': fieldId, 'file_name': file.name, 'file_size': file.size});
   return response.data;
 }
 
@@ -93,8 +93,9 @@ async function uploadParts(file: File, parts: PartInfo[]): Promise<UploadedPart[
  * @param parts the parts that were uploaded
  * @returns UploadResult
  */
-async function finalizeUpload(multipartInfo: MultipartInfo, parts: UploadedPart[], options: UploadOptions): Promise<undefined> {
+async function finalizeUpload(multipartInfo: MultipartInfo, parts: UploadedPart[], fieldId: string, options: UploadOptions): Promise<undefined> {
   await axios.post(`${options.baseUrl}/upload-finalize/`, {
+    field_id: fieldId,
     object_key: multipartInfo.object_key,
     upload_id: multipartInfo.upload_id,
     parts: parts,
@@ -108,11 +109,11 @@ async function finalizeUpload(multipartInfo: MultipartInfo, parts: UploadedPart[
  * @param file the file to upload
  * @param options the upload options
  */
-export async function uploadFile(file: File, options: UploadOptions): Promise<UploadResult> {
+export async function uploadFile(file: File, fieldId: string, options: UploadOptions): Promise<UploadResult> {
   // TODO most options are unused, but maintained for reverse compatibility
-  const multipartInfo = await initializeUpload(file, options);
+  const multipartInfo = await initializeUpload(file, fieldId, options);
   const parts = await uploadParts(file, multipartInfo.parts);
-  await finalizeUpload(multipartInfo, parts, options);
+  await finalizeUpload(multipartInfo, parts, fieldId, options);
   return {
     name: file.name,
     value: '',

--- a/s3_file_field/_multipart.py
+++ b/s3_file_field/_multipart.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import timedelta
 import math
-from typing import Iterator, List, Tuple
+from typing import TYPE_CHECKING, Iterator, List, Tuple
+
+if TYPE_CHECKING:
+    from .fields import S3FileField
 
 
 @dataclass

--- a/s3_file_field/_multipart_boto3.py
+++ b/s3_file_field/_multipart_boto3.py
@@ -11,7 +11,9 @@ from ._multipart import MultipartManager, UploadFinalization
 
 
 class Boto3MultipartManager(MultipartManager):
-    def __init__(self, storage: 'S3Boto3Storage'):
+    def __init__(self, field: 'S3FileField'):
+        super().__init__(field)
+        storage: 'S3Boto3Storage' = field.storage
         resource: s3.ServiceResource = storage.connection
         self._client: s3.Client = resource.meta.client
         self._bucket_name: str = storage.bucket_name

--- a/s3_file_field/_multipart_boto3.py
+++ b/s3_file_field/_multipart_boto3.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
 
     # S3Boto3Storage requires Django settings to be available at import time
     from storages.backends.s3boto3 import S3Boto3Storage
+    from .fields import S3FileField
 
 from ._multipart import MultipartManager, UploadFinalization
 

--- a/s3_file_field/_multipart_minio.py
+++ b/s3_file_field/_multipart_minio.py
@@ -5,7 +5,9 @@ from ._multipart import MultipartManager, UploadFinalization
 
 
 class MinioMultipartManager(MultipartManager):
-    def __init__(self, storage: MinioStorage):
+    def __init__(self, field: 'S3FileField'):
+        super().__init__(field)
+        storage: MinioStorage = field.storage
         self._client: minio.Minio = storage.client
         self._bucket_name: str = storage.bucket_name
         # To support MinioStorage's "base_url" functionality, an alternative client must be used

--- a/s3_file_field/_multipart_minio.py
+++ b/s3_file_field/_multipart_minio.py
@@ -1,3 +1,8 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .fields import S3FileField
+
 import minio
 from minio_storage.storage import MinioStorage
 

--- a/s3_file_field/checks.py
+++ b/s3_file_field/checks.py
@@ -6,7 +6,7 @@ from django.apps import AppConfig
 from django.core.checks import CheckMessage, Error, register
 
 from ._multipart import MultipartManager
-from ._registry import iter_storages
+from ._registry import iter_fields
 
 # TODO: this should only add a handler when running the check command
 logger = logging.getLogger(__name__)
@@ -27,17 +27,17 @@ def check_supported_storage_provider(
     # https://docs.djangoproject.com/en/3.1/topics/checks/#field-model-manager-and-database-checks
     return (
         []
-        if all(MultipartManager.supported_storage(storage) for storage in iter_storages())
+        if all(MultipartManager.supported_field_storage(field) for field in iter_fields())
         else [E001]
     )
 
 
 @register()
 def test_bucket_access(app_configs: Optional[Iterable[AppConfig]], **kwargs) -> List[CheckMessage]:
-    for storage in iter_storages():
-        if not MultipartManager.supported_storage(storage):
+    for field in iter_fields():
+        if not MultipartManager.supported_field_storage(field):
             continue
-        multipart = MultipartManager.from_storage(storage)
+        multipart = MultipartManager.from_field(field)
         try:
             multipart.test_upload()
         except ConnectionError:

--- a/s3_file_field/fields.py
+++ b/s3_file_field/fields.py
@@ -78,7 +78,7 @@ class S3FileField(FileField):
 
         This is an instance of "form_class", with a widget of "widget".
         """
-        if MultipartManager.supported_storage(self.storage):
+        if MultipartManager.supported_field_storage(self):
             # Use S3FormFileField as a default, instead of forms.FileField from the superclass
             kwargs.setdefault('form_class', S3FormFileField)
             # Allow the form and widget to lookup this field instance later, using its id

--- a/s3_file_field/views.py
+++ b/s3_file_field/views.py
@@ -3,7 +3,6 @@ from typing import Dict
 import uuid
 
 from django.conf import settings
-from django.core.files.storage import default_storage
 from django.http.response import HttpResponseBase
 from rest_framework import serializers
 from rest_framework.decorators import api_view, parser_classes
@@ -11,11 +10,12 @@ from rest_framework.parsers import JSONParser
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from . import _multipart
+from . import _multipart, _registry
 from ._multipart import PartFinalization, UploadFinalization
 
 
 class UploadRequestSerializer(serializers.Serializer):
+    field_id = serializers.CharField()
     file_name = serializers.CharField(trim_whitespace=False)
     file_size = serializers.IntegerField(min_value=1)
     # part_size = serializers.IntegerField(min_value=1)
@@ -43,6 +43,7 @@ class PartFinalizationSerializer(serializers.Serializer):
 
 
 class UploadFinalizationSerializer(serializers.Serializer):
+    field_id = serializers.CharField()
     object_key = serializers.CharField(trim_whitespace=False)
     upload_id = serializers.CharField()
     parts = PartFinalizationSerializer(many=True, allow_empty=False)
@@ -52,6 +53,7 @@ class UploadFinalizationSerializer(serializers.Serializer):
             PartFinalization(**part)
             for part in sorted(validated_data.pop('parts'), key=lambda part: part['part_number'])
         ]
+        validated_data.pop('field_id')
         return UploadFinalization(parts=parts, **validated_data)
 
 
@@ -63,11 +65,12 @@ def upload_initialize(request: Request) -> HttpResponseBase:
     request_serializer = UploadRequestSerializer(data=request.data)
     request_serializer.is_valid(raise_exception=True)
     upload_request: Dict = request_serializer.validated_data
+    field = _registry.get_field(upload_request['field_id'])
 
     s3ff_upload_prefix = PurePosixPath(getattr(settings, 'S3FF_UPLOAD_PREFIX', ''))
     object_key = str(s3ff_upload_prefix / str(uuid.uuid4()) / upload_request['file_name'])
 
-    initialization = _multipart.MultipartManager.from_storage(default_storage).initialize_upload(
+    initialization = _multipart.MultipartManager.from_field(field).initialize_upload(
         object_key, upload_request['file_size']
     )
 
@@ -89,6 +92,7 @@ def upload_initialize(request: Request) -> HttpResponseBase:
 def upload_finalize(request: Request) -> HttpResponseBase:
     finalization_serializer = UploadFinalizationSerializer(data=request.data)
     finalization_serializer.is_valid(raise_exception=True)
+    field = _registry.get_field(finalization_serializer.validated_data['field_id'])
     finalization = finalization_serializer.save()
 
     # check if upload_prepare signed this less than max age ago
@@ -98,7 +102,7 @@ def upload_finalize(request: Request) -> HttpResponseBase:
     # ):
     #     raise BadSignature()
 
-    _multipart.MultipartManager.from_storage(default_storage).finalize_upload(finalization)
+    _multipart.MultipartManager.from_field(field).finalize_upload(finalization)
 
     # signals.s3_file_field_upload_finalize.send(
     #     sender=multipart_upload_finalize, name=name, object_key=object_key

--- a/tests/functional/tests/test_multipart_upload.py
+++ b/tests/functional/tests/test_multipart_upload.py
@@ -13,7 +13,7 @@ def mb(bytes_size: int) -> int:
 def test_prepare(api_client):
     resp = api_client.post(
         '/api/joist/upload-initialize/',
-        {'file_name': 'test.txt', 'file_size': 10},
+        {'field_id': 'blobs.Blob.resource', 'file_name': 'test.txt', 'file_size': 10},
         format='json',
     )
     assert resp.status_code == 200
@@ -27,7 +27,7 @@ def test_prepare(api_client):
 def test_prepare_two_parts(api_client):
     resp = api_client.post(
         '/api/joist/upload-initialize/',
-        {'file_name': 'test.txt', 'file_size': mb(10)},
+        {'field_id': 'blobs.Blob.resource', 'file_name': 'test.txt', 'file_size': mb(10)},
         format='json',
     )
     assert resp.status_code == 200
@@ -45,7 +45,7 @@ def test_prepare_two_parts(api_client):
 def test_prepare_three_parts(api_client):
     resp = api_client.post(
         '/api/joist/upload-initialize/',
-        {'file_name': 'test.txt', 'file_size': mb(12)},
+        {'field_id': 'blobs.Blob.resource', 'file_name': 'test.txt', 'file_size': mb(12)},
         format='json',
     )
     assert resp.status_code == 200
@@ -65,7 +65,7 @@ def test_full_upload_flow(api_client: APIClient, file_size: int):
     # Initialize the multipart upload
     resp = api_client.post(
         '/api/joist/upload-initialize/',
-        {'file_name': 'test.txt', 'file_size': file_size},
+        {'field_id': 'blobs.Blob.resource', 'file_name': 'test.txt', 'file_size': file_size},
         format='json',
     )
     assert resp.status_code == 200
@@ -79,6 +79,8 @@ def test_full_upload_flow(api_client: APIClient, file_size: int):
         # Modify the part to transform it from an initialization to a finalization
         del part['upload_url']
         part['etag'] = resp.headers['ETag']
+
+    initialization['field_id'] = 'blobs.Blob.resource'
 
     # Finalize the upload
     resp = api_client.post(

--- a/tests/unit/test_fields.py
+++ b/tests/unit/test_fields.py
@@ -4,7 +4,7 @@ from s3_file_field.fields import S3FileField
 
 
 def test_field_id(s3ff_field: S3FileField):
-    assert s3ff_field.id == 's3ff_test.Resource.blob'
+    assert s3ff_field.id.startswith('s3ff_test.Resource.blob_')
 
 
 def test_field_id_premature():

--- a/tests/unit/test_multipart.py
+++ b/tests/unit/test_multipart.py
@@ -1,12 +1,8 @@
-from django.core.files.storage import FileSystemStorage, Storage
-from minio_storage.storage import MinioStorage
 import pytest
 import requests
-from storages.backends.s3boto3 import S3Boto3Storage
 
 from s3_file_field._multipart import MultipartManager, PartFinalization, UploadFinalization
-from s3_file_field._multipart_boto3 import Boto3MultipartManager
-from s3_file_field._multipart_minio import MinioMultipartManager
+from s3_file_field.fields import S3FileField
 
 
 def mb(bytes_size: int) -> int:
@@ -18,27 +14,16 @@ def gb(bytes_size: int) -> int:
 
 
 @pytest.fixture
-def boto3_multipart_manager(s3boto3_storage: S3Boto3Storage) -> Boto3MultipartManager:
-    return Boto3MultipartManager(s3boto3_storage)
+def multipart_manager(s3ff_field: S3FileField) -> MultipartManager:
+    return MultipartManager.from_field(s3ff_field)
 
 
-@pytest.fixture
-def minio_multipart_manager(minio_storage: MinioStorage) -> MinioMultipartManager:
-    return MinioMultipartManager(minio_storage)
+def test_multipart_manager_supported_field_storage(s3ff_field: S3FileField):
+    assert MultipartManager.supported_field_storage(s3ff_field)
 
 
-@pytest.fixture
-def multipart_manager(storage: Storage) -> MultipartManager:
-    return MultipartManager.from_storage(storage)
-
-
-def test_multipart_manager_supported_storage(storage: Storage):
-    assert MultipartManager.supported_storage(storage)
-
-
-def test_multipart_manager_supported_storage_unsupported():
-    storage = FileSystemStorage()
-    assert not MultipartManager.supported_storage(storage)
+def test_multipart_manager_supported_field_storage_unsupported(s3ff_field_invalid):
+    assert not MultipartManager.supported_field_storage(s3ff_field_invalid)
 
 
 def test_multipart_manager_initialize_upload(multipart_manager: MultipartManager):

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -1,5 +1,3 @@
-from django.core.files.storage import default_storage
-
 from s3_file_field import _registry
 from s3_file_field.fields import S3FileField
 
@@ -11,12 +9,12 @@ def test_registry_get_field(s3ff_field: S3FileField):
 def test_registry_iter_fields(s3ff_field: S3FileField):
     fields = list(_registry.iter_fields())
 
-    assert len(fields) == 2
+    assert len(fields) == 3
     assert any(field is s3ff_field for field in fields)
 
 
 def test_registry_iter_storages(s3ff_field: S3FileField):
-    fields = list(_registry.iter_storages())
+    storages = list(_registry.iter_storages())
 
-    assert len(fields) == 1
-    assert fields[0] is default_storage
+    assert len(storages) == 3
+    assert any(storage is s3ff_field.storage for storage in storages)

--- a/tests/unit/test_serializers.py
+++ b/tests/unit/test_serializers.py
@@ -36,6 +36,7 @@ def initialization() -> UploadInitialization:
 def test_upload_request_deserialization():
     serializer = UploadRequestSerializer(
         data={
+            'field_id': 'package.Class.field',
             'file_name': 'test-name.jpg',
             'file_size': 15,
         }
@@ -55,6 +56,7 @@ def test_upload_initialization_serialization(
 def test_upload_finalization_deserialization():
     serializer = UploadFinalizationSerializer(
         data={
+            'field_id': 'package.Class.field',
             'object_key': 'test-object-key',
             'upload_id': 'test-upload-id',
             'parts': [


### PR DESCRIPTION
MultipartManagers are now initialized with a factory method `from_field` instead of `from_storage`. They also store this field for later reference. Uploads now happen to the storage specified for a field. Upload initialize and finalize calls now require an additional field, `field_id` specifying the field being uploaded to.