### PR TITLE
Add valid value to uploaded S3FileInput

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -116,7 +116,12 @@ export async function uploadFile(file: File, fieldId: string, options: UploadOpt
   await finalizeUpload(multipartInfo, parts, fieldId, options);
   return {
     name: file.name,
-    value: '',
+    value: JSON.stringify({
+      name: multipartInfo.object_key,
+      size: file.size,
+      id: multipartInfo.object_key,
+      signature: '',
+    }),
     state: 'successful',
     msg: '',
   }

--- a/s3_file_field/forms.py
+++ b/s3_file_field/forms.py
@@ -1,10 +1,9 @@
 from typing import Dict, Optional, Type, Union
 
 from django.contrib.admin.widgets import AdminFileWidget
-from django.core.signing import BadSignature, Signer
-from django.forms import FileField, ValidationError, Widget
+from django.forms import FileField, Widget
 
-from .widgets import AdminS3FileInput, S3FakeFile, S3FileInput
+from .widgets import AdminS3FileInput, S3FileInput
 
 
 class S3FormFileField(FileField):

--- a/s3_file_field/forms.py
+++ b/s3_file_field/forms.py
@@ -50,15 +50,15 @@ class S3FormFileField(FileField):
         # It will be added at render-time by "S3FileInput.get_context".
         return attrs
 
-    def validate(self, value):
-        super().validate(value)
+    # def validate(self, value):
+    #     super().validate(value)
 
-        if isinstance(value, S3FakeFile):
-            # verify signature
-            signer = Signer()
-            try:
-                expected = signer.unsign(value.signature)
-                if value.name != expected:
-                    raise ValidationError('Signature tempering detected')
-            except BadSignature:
-                raise ValidationError('Signature tempering detected')
+    #     if isinstance(value, S3FakeFile):
+    #         # verify signature
+    #         signer = Signer()
+    #         try:
+    #             expected = signer.unsign(value.signature)
+    #             if value.name != expected:
+    #                 raise ValidationError('Signature tempering detected')
+    #         except BadSignature:
+    #             raise ValidationError('Signature tempering detected')

--- a/s3_file_field/views.py
+++ b/s3_file_field/views.py
@@ -1,6 +1,5 @@
 from pathlib import PurePosixPath
 from typing import Dict
-import uuid
 
 from django.conf import settings
 from django.http.response import HttpResponseBase
@@ -68,7 +67,10 @@ def upload_initialize(request: Request) -> HttpResponseBase:
     field = _registry.get_field(upload_request['field_id'])
 
     s3ff_upload_prefix = PurePosixPath(getattr(settings, 'S3FF_UPLOAD_PREFIX', ''))
-    object_key = str(s3ff_upload_prefix / str(uuid.uuid4()) / upload_request['file_name'])
+    # object_key = str(s3ff_upload_prefix / str(uuid.uuid4()) / upload_request['file_name'])
+    object_key = str(
+        s3ff_upload_prefix / field.generate_filename(None, upload_request['file_name'])
+    )
 
     initialization = _multipart.MultipartManager.from_storage(field.storage).initialize_upload(
         object_key, upload_request['file_size']


### PR DESCRIPTION
When adding the multipart client I set the `value` on the `<input>` element in the form to `''` as a placeholder, as I didn't think it was significant. That value is passed in to the S3FakeFile and will fail validation if it isn't correctly formatted.

That value also involves a signature that is not calculated in multipart uploads, so I removed that S3FakeFile validation step.

Submitting the test/functional form works correctly now.