### PR TITLE
Use upload_to instead of hardcoded UUID prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ your configuration is correct, run:
 | Key                  | Default          | Description                                 |
 | -------------------  | ---------------- | ------------------------------------------- |
 | S3FF_UPLOAD_STS_ARN  | none             | ...                                         |
-| S3FF_UPLOAD_PREFIX   | none             | Prefix where files should be stored         |
 
 
 #### STS configuration

--- a/s3_file_field/views.py
+++ b/s3_file_field/views.py
@@ -1,7 +1,5 @@
-from pathlib import PurePosixPath
 from typing import Dict
 
-from django.conf import settings
 from django.http.response import HttpResponseBase
 from rest_framework import serializers
 from rest_framework.decorators import api_view, parser_classes
@@ -69,7 +67,7 @@ def upload_initialize(request: Request) -> HttpResponseBase:
     # TODO The first argument to generate_filename() is an instance of the model.
     # We do not and will never have an instance of the model during field upload.
     # Maybe we need a different generate method/upload_to with a different signature?
-    object_key = str(field.generate_filename(None, upload_request['file_name']))
+    object_key = field.generate_filename(None, upload_request['file_name'])
 
     initialization = _multipart.MultipartManager.from_storage(field.storage).initialize_upload(
         object_key, upload_request['file_size']

--- a/s3_file_field/views.py
+++ b/s3_file_field/views.py
@@ -1,6 +1,5 @@
 from pathlib import PurePosixPath
 from typing import Dict
-import uuid
 
 from django.conf import settings
 from django.http.response import HttpResponseBase
@@ -68,7 +67,12 @@ def upload_initialize(request: Request) -> HttpResponseBase:
     field = _registry.get_field(upload_request['field_id'])
 
     s3ff_upload_prefix = PurePosixPath(getattr(settings, 'S3FF_UPLOAD_PREFIX', ''))
-    object_key = str(s3ff_upload_prefix / str(uuid.uuid4()) / upload_request['file_name'])
+    # TODO The first argument to generate_filename() is an instance of the model.
+    # We do not and will never have an instance of the model during field upload.
+    # Maybe we need a different generate method/upload_to with a different signature?
+    object_key = str(
+        s3ff_upload_prefix / field.generate_filename(None, upload_request['file_name'])
+    )
 
     initialization = _multipart.MultipartManager.from_storage(field.storage).initialize_upload(
         object_key, upload_request['file_size']

--- a/s3_file_field/views.py
+++ b/s3_file_field/views.py
@@ -66,13 +66,10 @@ def upload_initialize(request: Request) -> HttpResponseBase:
     upload_request: Dict = request_serializer.validated_data
     field = _registry.get_field(upload_request['field_id'])
 
-    s3ff_upload_prefix = PurePosixPath(getattr(settings, 'S3FF_UPLOAD_PREFIX', ''))
     # TODO The first argument to generate_filename() is an instance of the model.
     # We do not and will never have an instance of the model during field upload.
     # Maybe we need a different generate method/upload_to with a different signature?
-    object_key = str(
-        s3ff_upload_prefix / field.generate_filename(None, upload_request['file_name'])
-    )
+    object_key = str(field.generate_filename(None, upload_request['file_name']))
 
     initialization = _multipart.MultipartManager.from_storage(field.storage).initialize_upload(
         object_key, upload_request['file_size']


### PR DESCRIPTION
Using `generate_filename`/`upload_to` seems like the correct answer, but I really don't like having to ignore the `instance` argument. It's assumed that `generate_filename` is being used to create a new model during a form submission, but during upload we don't have a model instance we can pass. Using `None` is hacky, but seems less hacky to me than reimplementing `generate_filename`.