### PR TITLE
Remove unnecessary flex from admin widget

### DIFF
--- a/client/src/style.scss
+++ b/client/src/style.scss
@@ -1,10 +1,5 @@
 $css_prefix: s3fileinput;
 
-.#{$css_prefix}-wrapper {
-  display: flex;
-  flex-direction: column;
-}
-
 .#{$css_prefix}-inner {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Fixes #106

Safari was rendering the component strangely because of an unnecessary `flex-column` class. After removal the admin widget renders the same for me in Safari and in Chrome.