### PR TITLE
Coerce FieldFile content out of an S3FakeFile before saving

### DIFF
--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -37,7 +37,6 @@ def test_form_validation(storage_object_key):
     assert form.is_valid()
 
 
-@pytest.mark.xfail
 def test_form_instance(storage_object_key):
     data = json.dumps(
         {


### PR DESCRIPTION
This should result in the model having a normal, sane `FieldFile` (wrapping an ordinary `File` subclass) after saving.

Fixes #105.