### PR TITLE
Allow form fields to handle empty and cleared uploads

### DIFF
--- a/s3_file_field/fields.py
+++ b/s3_file_field/fields.py
@@ -11,7 +11,7 @@ from django.forms import Field as FormField
 from ._multipart import MultipartManager
 from ._registry import register_field
 from .forms import S3FormFileField
-from .widgets import S3FakeFile
+from .widgets import S3PlaceholderFile
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ class S3FieldFile(FieldFile):
     """
 
     def save(self, name: str, content: Any, save=True):
-        if not isinstance(content, S3FakeFile):
+        if not isinstance(content, S3PlaceholderFile):
             return super().save(name, content, save)
 
         self.name = content.name
@@ -99,9 +99,9 @@ class S3FileField(FileField):
         # database, and no save occurs, which is desirable here.
         # However, we don't want the S3FileInput or S3FormFileField to emit a string value,
         # since that will break most of the default validation.
-        # TODO: data might be False, if the field is being cleared
-        file: str = data.name
-        super().save_form_data(instance, file)
+        if isinstance(data, S3PlaceholderFile):
+            data = data.name
+        super().save_form_data(instance, data)
 
     # Ignore type due to: https://github.com/typeddjango/django-stubs/pull/497
     def check(self, **kwargs) -> List[CheckMessage]:  # type: ignore

--- a/s3_file_field/forms.py
+++ b/s3_file_field/forms.py
@@ -52,7 +52,7 @@ class S3FormFileField(FileField):
     # def validate(self, value):
     #     super().validate(value)
 
-    #     if isinstance(value, S3FakeFile):
+    #     if isinstance(value, S3PlaceholderFile):
     #         # verify signature
     #         signer = Signer()
     #         try:

--- a/s3_file_field/widgets.py
+++ b/s3_file_field/widgets.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 import functools
 import json
 import posixpath
-from typing import Any, Dict, Iterable, Mapping
+from typing import Any, Dict, Iterable, Mapping, Optional
 
+from django.core.files import File
 from django.forms import ClearableFileInput
+from django.forms.widgets import FILE_INPUT_CONTRADICTION, CheckboxInput  # type: ignore
 from django.urls import reverse
 
 
@@ -15,30 +19,42 @@ def get_base_url() -> str:
     return posixpath.commonpath([prepare_url, finalize_url])
 
 
-class S3FakeFile:
-    """
-    helper object to act similar to an UploadedFile.
+class S3PlaceholderFile(File):
+    def __init__(self, name, size):
+        self.name = name
+        self.size = size
 
-    But without the data since they already have been uploaded.
-    """
+    # @property
+    # def size(self) -> int:
+    #     return 0
 
-    def __init__(self, info: Mapping[str, Any]):
-        super().__init__()
+    def open(self, mode=None):
+        raise NotImplementedError
 
-        self.name: str = info['id']
-        self.original_name: str = info['name']
-        self.size: int = info['size']
-        self.signature: str = info['signature']
-        self._committed = True
+    def close(self):
+        raise NotImplementedError
 
-    def __str__(self):
-        return self.name
+    def chunks(self, chunk_size=None):
+        raise NotImplementedError
 
-    def bool(self):
-        return bool(self.name)
+    def multiple_chunks(self, chunk_size=None) -> bool:
+        # Since it's in memory, we'll never have multiple chunks.
+        return False
 
-    def len(self):
-        return self.size
+    @classmethod
+    def from_field(cls, field_value: str) -> Optional[S3PlaceholderFile]:
+        try:
+            parsed_field = json.loads(field_value)
+        except json.JSONDecodeError:
+            pass
+        else:
+            if isinstance(parsed_field, dict) and 'id' in parsed_field:
+                file_name = parsed_field['id']
+                if isinstance(file_name, str):
+                    # TODO: validate size
+                    size = int(parsed_field.get('size', 1))
+                    return cls(file_name, size)
+        return None
 
 
 class S3FileInput(ClearableFileInput):
@@ -58,14 +74,37 @@ class S3FileInput(ClearableFileInput):
     def value_from_datadict(
         self, data: Dict[str, Any], files: Mapping[str, Iterable[Any]], name: str
     ):
-        if name not in files and data.get(name):
-            # JSON fake file
-            return S3FakeFile(json.loads(data[name]))
-        return super().value_from_datadict(data, files, name)
+        if name in data:
+            upload = data[name]
+            # An empty string indicates the field was not populated, so don't wrap it in a File
+            if upload != '':
+                upload = S3PlaceholderFile.from_field(upload)
+        elif name in files:
+            # Files were uploaded, client JS library may not be functioning
+            # So, fallback to direct upload
+            upload = super().value_from_datadict(data, files, name)
+        else:
+            upload = None
 
-    def value_omitted_from_data(self, data: Mapping[str, Any], files: Mapping[str, Any], name: str):
+        if not self.is_required and CheckboxInput().value_from_datadict(
+            data, files, self.clear_checkbox_name(name)
+        ):
+            if upload:
+                # If the user contradicts themselves (uploads a new file AND
+                # checks the "clear" checkbox), we return a unique marker
+                # object that FileField will turn into a ValidationError.
+                return FILE_INPUT_CONTRADICTION
+            # False signals to clear any existing value, as opposed to just None
+            return False
+        return upload
+
+    def value_omitted_from_data(
+        self, data: Mapping[str, Any], files: Mapping[str, Any], name: str
+    ) -> bool:
         return (
-            name not in files and not data.get(name) and self.clear_checkbox_name(name) not in data
+            (name not in data)
+            and (name not in files)
+            and (self.clear_checkbox_name(name) not in data)
         )
 
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -73,3 +73,11 @@ def test_form_instance_saved(storage_object_key):
 
     with resource.blob.open() as blob_stream:
         assert blob_stream.read() == b'test content'
+
+
+@pytest.mark.parametrize('value', ['', '""', 'null', '{}', json.dumps({'id': ''})])
+@pytest.mark.django_db
+def test_form_empty(storage_object_key, value):
+    form = ResourceForm(data={'blob': value})
+
+    assert not form.is_valid()


### PR DESCRIPTION
The reworks the parsing and validation pipeline to be more compatible with the way that Django's form `Field.clean` works. S3FF now properly handles empty form submissions (and has basic tests for this) without raising a 500. It also theoretically supports the usage of the "clear" checkbox for fields where `blank=True`, but further testing should be added in a subsequent PR.