### PR TITLE
Presign finalize

### DIFF
--- a/django-s3-file-field-client/src/client.ts
+++ b/django-s3-file-field-client/src/client.ts
@@ -8,6 +8,7 @@ interface PartInfo {
 }
 // Description of the upload from initializeUpload()
 interface MultipartInfo {
+  upload_signature: string;
   object_key: string;
   upload_id: string;
   parts: PartInfo[];
@@ -90,16 +91,14 @@ export default class S3FFClient {
    * @param parts the parts that were uploaded
    * @returns finalization signed information needed by /finalize/
    */
-  protected async completeUpload(multipartInfo: MultipartInfo, parts: UploadedPart[], fieldId: string): Promise<string> {
+  protected async completeUpload(multipartInfo: MultipartInfo, parts: UploadedPart[]): Promise<void> {
     const response = await axios.post(`${this.baseUrl}/upload-complete/`, {
-      field_id: fieldId,
-      object_key: multipartInfo.object_key,
+      upload_signature: multipartInfo.upload_signature,
       upload_id: multipartInfo.upload_id,
       parts: parts,
     });
-    const { complete_url, body, finalization } = response.data;
+    const { complete_url, body } = response.data;
     await axios.post(complete_url, body);
-    return finalization;
   }
 
   /**
@@ -109,9 +108,9 @@ export default class S3FFClient {
    * @param finalization signed information returned from /upload-complete/
    * @returns signed field_value containing an object_key and a size
    */
-  protected async finalize(finalization: string): Promise<string> {
+  protected async finalize(multipartInfo: MultipartInfo): Promise<string> {
     const response = await axios.post(`${this.baseUrl}/finalize/`, {
-      finalization: finalization,
+      upload_signature: multipartInfo.upload_signature,
     });
     const { field_value } = response.data;
     return field_value;
@@ -126,8 +125,8 @@ export default class S3FFClient {
   public async uploadFile(file: File, fieldId: string): Promise<UploadResult> {
     const multipartInfo = await this.initializeUpload(file, fieldId);
     const parts = await this.uploadParts(file, multipartInfo.parts);
-    const finalization = await this.completeUpload(multipartInfo, parts, fieldId);
-    const field_value = await this.finalize(finalization);
+    await this.completeUpload(multipartInfo, parts);
+    const field_value = await this.finalize(multipartInfo);
     return {
       value: field_value,
       state: 'successful',

--- a/django-s3-file-field-client/src/client.ts
+++ b/django-s3-file-field-client/src/client.ts
@@ -101,7 +101,11 @@ export default class S3FFClient {
       upload_id: multipartInfo.upload_id,
       parts: parts,
     });
-    return response.data;
+    const { finalize_url, body, field_value } = response.data;
+    await axios.post(finalize_url, body);
+    return {
+      field_value: field_value,
+    };
   }
 
   /**

--- a/s3_file_field/_multipart.py
+++ b/s3_file_field/_multipart.py
@@ -149,7 +149,7 @@ class MultipartManager:
     def _generate_presigned_complete_url(self, completion: UploadCompletion) -> str:
         raise NotImplementedError
 
-    def get_upload_size(self, object_key: str) -> int:
+    def get_object_size(self, object_key: str) -> int:
         raise NotImplementedError
 
     @staticmethod

--- a/s3_file_field/_multipart.py
+++ b/s3_file_field/_multipart.py
@@ -23,22 +23,22 @@ class InitializedUpload:
 
 
 @dataclass
-class PartFinalization:
+class PartCompletion:
     part_number: int
     size: int
     etag: str
 
 
 @dataclass
-class UploadFinalization:
+class UploadCompletion:
     object_key: str
     upload_id: str
-    parts: List[PartFinalization]
+    parts: List[PartCompletion]
 
 
 @dataclass
-class FinalizedUpload:
-    finalize_url: str
+class CompletedUpload:
+    complete_url: str
     body: str
 
 
@@ -67,15 +67,15 @@ class MultipartManager:
         ]
         return InitializedUpload(object_key=object_key, upload_id=upload_id, parts=parts)
 
-    def finalize_upload(self, finalization: UploadFinalization) -> FinalizedUpload:
-        finalize_url = self._generate_presigned_finalize_url(finalization)
-        body = self.marshal_finalize_body(finalization)
-        return FinalizedUpload(finalize_url=finalize_url, body=body)
+    def complete_upload(self, completion: UploadCompletion) -> CompletedUpload:
+        complete_url = self._generate_presigned_complete_url(completion)
+        body = self._marshal_complete_body(completion)
+        return CompletedUpload(complete_url=complete_url, body=body)
 
-    def marshal_finalize_body(self, finalization: UploadFinalization) -> str:
-        """Generate the body of a presigned finalize request."""
+    def _marshal_complete_body(self, completion: UploadCompletion) -> str:
+        """Generate the body of a presigned completion request."""
         body = '<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
-        for part in finalization.parts:
+        for part in completion.parts:
             body += '<Part>'
             body += f'<PartNumber>{part.part_number}</PartNumber>'
             body += f'<ETag>{part.etag}</ETag>'
@@ -141,7 +141,10 @@ class MultipartManager:
     ) -> str:
         raise NotImplementedError
 
-    def _generate_presigned_finalize_url(self, finalization: UploadFinalization) -> str:
+    def _generate_presigned_complete_url(self, completion: UploadCompletion) -> str:
+        raise NotImplementedError
+
+    def get_upload_size(self, object_key: str) -> int:
         raise NotImplementedError
 
     @staticmethod

--- a/s3_file_field/_multipart.py
+++ b/s3_file_field/_multipart.py
@@ -69,12 +69,17 @@ class MultipartManager:
 
     def complete_upload(self, completion: UploadCompletion) -> CompletedUpload:
         complete_url = self._generate_presigned_complete_url(completion)
-        body = self._marshal_complete_body(completion)
+        body = self._generate_presigned_complete_body(completion)
         return CompletedUpload(complete_url=complete_url, body=body)
 
-    def _marshal_complete_body(self, completion: UploadCompletion) -> str:
-        """Generate the body of a presigned completion request."""
-        body = '<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+    def _generate_presigned_complete_body(self, completion: UploadCompletion) -> str:
+        """
+        Generate the body of a presigned completion request.
+
+        See https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
+        """
+        body = '<?xml version="1.0" encoding="UTF-8"?>'
+        body += '<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
         for part in completion.parts:
             body += '<Part>'
             body += f'<PartNumber>{part.part_number}</PartNumber>'

--- a/s3_file_field/_multipart.py
+++ b/s3_file_field/_multipart.py
@@ -48,6 +48,12 @@ class UnsupportedStorageException(Exception):
     pass
 
 
+class ObjectNotFoundException(Exception):
+    """Raised when an object cannot be found in the object store."""
+
+    pass
+
+
 class MultipartManager:
     """A facade providing management of S3 multipart uploads to multiple Storages."""
 

--- a/s3_file_field/_multipart_boto3.py
+++ b/s3_file_field/_multipart_boto3.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     # mypy_boto3_s3 only provides types
     import mypy_boto3_s3 as s3
 
-from ._multipart import MultipartManager, UploadCompletion
+from ._multipart import MultipartManager, TransferredParts
 
 
 class Boto3MultipartManager(MultipartManager):
@@ -50,13 +50,13 @@ class Boto3MultipartManager(MultipartManager):
             ExpiresIn=int(self._url_expiration.total_seconds()),
         )
 
-    def _generate_presigned_complete_url(self, completion: UploadCompletion) -> str:
+    def _generate_presigned_complete_url(self, transferred_parts: TransferredParts) -> str:
         return self._client.generate_presigned_url(
             ClientMethod='complete_multipart_upload',
             Params={
                 'Bucket': self._bucket_name,
-                'Key': completion.object_key,
-                'UploadId': completion.upload_id,
+                'Key': transferred_parts.object_key,
+                'UploadId': transferred_parts.upload_id,
             },
             ExpiresIn=int(self._url_expiration.total_seconds()),
         )

--- a/s3_file_field/_multipart_boto3.py
+++ b/s3_file_field/_multipart_boto3.py
@@ -49,22 +49,13 @@ class Boto3MultipartManager(MultipartManager):
             ExpiresIn=int(self._url_expiration.total_seconds()),
         )
 
-    def finalize_upload(self, finalization: UploadFinalization) -> None:
-        # TODO: from
-        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.complete_multipart_upload
-        # "Processing of a Complete Multipart Upload request could
-        # take several minutes to complete."
-        self._client.complete_multipart_upload(
-            Bucket=self._bucket_name,
-            Key=finalization.object_key,
-            UploadId=finalization.upload_id,
-            MultipartUpload={
-                'Parts': [
-                    {
-                        'PartNumber': part.part_number,
-                        'ETag': part.etag,
-                    }
-                    for part in finalization.parts
-                ],
+    def _generate_presigned_finalize_url(self, finalization: UploadFinalization) -> str:
+        return self._client.generate_presigned_url(
+            ClientMethod='complete_multipart_upload',
+            Params={
+                'Bucket': self._bucket_name,
+                'Key': finalization.object_key,
+                'UploadId': finalization.upload_id,
             },
+            ExpiresIn=int(self._url_expiration.total_seconds()),
         )

--- a/s3_file_field/_multipart_boto3.py
+++ b/s3_file_field/_multipart_boto3.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     # mypy_boto3_s3 only provides types
     import mypy_boto3_s3 as s3
 
-from ._multipart import MultipartManager, TransferredParts
+from ._multipart import MultipartManager, ObjectNotFoundException, TransferredParts
 
 
 class Boto3MultipartManager(MultipartManager):
@@ -69,4 +69,4 @@ class Boto3MultipartManager(MultipartManager):
             )
             return stats['ContentLength']
         except ClientError:
-            raise ValueError('Object not found')
+            raise ObjectNotFoundException()

--- a/s3_file_field/_multipart_boto3.py
+++ b/s3_file_field/_multipart_boto3.py
@@ -61,7 +61,7 @@ class Boto3MultipartManager(MultipartManager):
             ExpiresIn=int(self._url_expiration.total_seconds()),
         )
 
-    def get_upload_size(self, object_key: str) -> int:
+    def get_object_size(self, object_key: str) -> int:
         try:
             stats = self._client.head_object(
                 Bucket=self._bucket_name,

--- a/s3_file_field/_multipart_minio.py
+++ b/s3_file_field/_multipart_minio.py
@@ -1,7 +1,7 @@
 import minio
 from minio_storage.storage import MinioStorage
 
-from ._multipart import MultipartManager, TransferredParts
+from ._multipart import MultipartManager, ObjectNotFoundException, TransferredParts
 
 
 class MinioMultipartManager(MultipartManager):
@@ -62,4 +62,4 @@ class MinioMultipartManager(MultipartManager):
             stats = self._client.stat_object(bucket_name=self._bucket_name, object_name=object_key)
             return stats.size
         except minio.error.NoSuchKey:
-            raise ValueError('Object not found')
+            raise ObjectNotFoundException()

--- a/s3_file_field/_multipart_minio.py
+++ b/s3_file_field/_multipart_minio.py
@@ -57,7 +57,7 @@ class MinioMultipartManager(MultipartManager):
             },
         )
 
-    def get_upload_size(self, object_key: str) -> int:
+    def get_object_size(self, object_key: str) -> int:
         try:
             stats = self._client.stat_object(bucket_name=self._bucket_name, object_name=object_key)
             return stats.size

--- a/s3_file_field/_multipart_minio.py
+++ b/s3_file_field/_multipart_minio.py
@@ -1,7 +1,7 @@
 import minio
 from minio_storage.storage import MinioStorage
 
-from ._multipart import MultipartManager, UploadCompletion
+from ._multipart import MultipartManager, TransferredParts
 
 
 class MinioMultipartManager(MultipartManager):
@@ -46,14 +46,14 @@ class MinioMultipartManager(MultipartManager):
             # }
         )
 
-    def _generate_presigned_complete_url(self, completion: UploadCompletion) -> str:
+    def _generate_presigned_complete_url(self, transferred_parts: TransferredParts) -> str:
         return self._signing_client.presigned_url(
             method='POST',
             bucket_name=self._bucket_name,
-            object_name=completion.object_key,
+            object_name=transferred_parts.object_key,
             expires=self._url_expiration,
             response_headers={
-                'uploadId': completion.upload_id,
+                'uploadId': transferred_parts.upload_id,
             },
         )
 

--- a/s3_file_field/urls.py
+++ b/s3_file_field/urls.py
@@ -1,14 +1,15 @@
 from django.urls import path
 
-from .views import upload_finalize, upload_initialize
+from .views import finalize, upload_complete, upload_initialize
 
 app_name = 's3_file_field'
 
 urlpatterns = [
     path('upload-initialize/', upload_initialize, name='upload-initialize'),
     path(
-        'upload-finalize/',
-        upload_finalize,
-        name='upload-finalize',
+        'upload-complete/',
+        upload_complete,
+        name='upload-complete',
     ),
+    path('finalize/', finalize, name='finalize'),
 ]

--- a/s3_file_field/views.py
+++ b/s3_file_field/views.py
@@ -162,22 +162,12 @@ def finalize(request: Request) -> HttpResponseBase:
 
     field = _registry.get_field(field_id)
 
-    # check if upload_prepare signed this less than max age ago
-    # tsigner = TimestampSigner()
-    # if object_key != tsigner.unsign(
-    #     upload_sig, max_age=int(MultipartManager._url_expiration.total_seconds())
-    # ):
-    #     raise BadSignature()
-
+    # get_object_size implicitly verifies that the object exists.
+    # We don't want to distribute the field value if the upload did not complete.
     try:
         size = _multipart.MultipartManager.from_storage(field.storage).get_object_size(object_key)
     except ValueError:
-        # The upload did not complete, do not finalize
         return Response('Object not found', status=400)
-
-    # signals.s3_file_field_upload_finalize.send(
-    #     sender=multipart_upload_finalize, name=name, object_key=object_key
-    # )
 
     field_value = signing.dumps(
         {

--- a/s3_file_field/views.py
+++ b/s3_file_field/views.py
@@ -9,7 +9,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from . import _multipart, _registry
-from ._multipart import TransferredPart, TransferredParts
+from ._multipart import ObjectNotFoundException, TransferredPart, TransferredParts
 
 
 class UploadInitializationRequestSerializer(serializers.Serializer):
@@ -166,7 +166,7 @@ def finalize(request: Request) -> HttpResponseBase:
     # We don't want to distribute the field value if the upload did not complete.
     try:
         size = _multipart.MultipartManager.from_storage(field.storage).get_object_size(object_key)
-    except ValueError:
+    except ObjectNotFoundException:
         return Response('Object not found', status=400)
 
     field_value = signing.dumps(

--- a/s3_file_field/views.py
+++ b/s3_file_field/views.py
@@ -164,7 +164,7 @@ def finalize(request: Request) -> HttpResponseBase:
     #     raise BadSignature()
 
     try:
-        size = _multipart.MultipartManager.from_storage(field.storage).get_upload_size(object_key)
+        size = _multipart.MultipartManager.from_storage(field.storage).get_object_size(object_key)
     except ValueError:
         # The upload did not complete, do not finalize
         return Response('Object not found', status=400)

--- a/s3_file_field/views.py
+++ b/s3_file_field/views.py
@@ -56,6 +56,8 @@ class UploadFinalizationRequestSerializer(serializers.Serializer):
 
 
 class UploadFinalizationResponseSerializer(serializers.Serializer):
+    finalize_url = serializers.URLField()
+    body = serializers.CharField(trim_whitespace=False)
     field_value = serializers.CharField(trim_whitespace=False)
 
 
@@ -106,7 +108,9 @@ def upload_finalize(request: Request) -> HttpResponseBase:
     # ):
     #     raise BadSignature()
 
-    _multipart.MultipartManager.from_storage(field.storage).finalize_upload(finalization)
+    finalized_upload = _multipart.MultipartManager.from_storage(field.storage).finalize_upload(
+        finalization
+    )
 
     # signals.s3_file_field_upload_finalize.send(
     #     sender=multipart_upload_finalize, name=name, object_key=object_key
@@ -121,6 +125,8 @@ def upload_finalize(request: Request) -> HttpResponseBase:
 
     response_serializer = UploadFinalizationResponseSerializer(
         {
+            'finalize_url': finalized_upload.finalize_url,
+            'body': finalized_upload.body,
             'field_value': field_value,
         }
     )

--- a/s3_file_field/widgets.py
+++ b/s3_file_field/widgets.py
@@ -14,7 +14,7 @@ from django.urls import reverse
 @functools.lru_cache(maxsize=1)
 def get_base_url() -> str:
     prepare_url = reverse('s3_file_field:upload-initialize')
-    finalize_url = reverse('s3_file_field:upload-finalize')
+    finalize_url = reverse('s3_file_field:upload-complete')
     # Use posixpath to always parse URL paths with forward slashes
     return posixpath.commonpath([prepare_url, finalize_url])
 

--- a/s3_file_field/widgets.py
+++ b/s3_file_field/widgets.py
@@ -14,9 +14,9 @@ from django.urls import reverse
 @functools.lru_cache(maxsize=1)
 def get_base_url() -> str:
     prepare_url = reverse('s3_file_field:upload-initialize')
-    finalize_url = reverse('s3_file_field:upload-complete')
+    complete_url = reverse('s3_file_field:upload-complete')
     # Use posixpath to always parse URL paths with forward slashes
-    return posixpath.commonpath([prepare_url, finalize_url])
+    return posixpath.commonpath([prepare_url, complete_url])
 
 
 class S3PlaceholderFile(File):

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -176,8 +176,8 @@ def test_multipart_manager_generate_presigned_complete_url(multipart_manager: Mu
     assert isinstance(upload_url, str)
 
 
-def test_multipart_manager_marshal_complete_body(multipart_manager: MultipartManager):
-    body = multipart_manager._marshal_complete_body(
+def test_multipart_manager_generate_presigned_complete_body(multipart_manager: MultipartManager):
+    body = multipart_manager._generate_presigned_complete_body(
         UploadCompletion(
             object_key='new-object',
             upload_id='fake-upload-id',
@@ -189,6 +189,7 @@ def test_multipart_manager_marshal_complete_body(multipart_manager: MultipartMan
     )
 
     assert body == (
+        '<?xml version="1.0" encoding="UTF-8"?>'
         '<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
         '<Part><PartNumber>1</PartNumber><ETag>fake-etag-1</ETag></Part>'
         '<Part><PartNumber>2</PartNumber><ETag>fake-etag-2</ETag></Part>'

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -133,10 +133,10 @@ def test_multipart_manager_complete_upload(multipart_manager: MultipartManager, 
             PartCompletion(part_number=part.part_number, size=part.size, etag=resp.headers['ETag'])
         )
 
-    finalization = multipart_manager.complete_upload(completion)
-    assert finalization
-    assert finalization.complete_url
-    assert finalization.body
+    completion = multipart_manager.complete_upload(completion)
+    assert completion
+    assert completion.complete_url
+    assert completion.body
 
 
 def test_multipart_manager_test_upload(multipart_manager: MultipartManager):

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -9,7 +9,7 @@ import pytest
 import requests
 from storages.backends.s3boto3 import S3Boto3Storage
 
-from s3_file_field._multipart import MultipartManager, PartFinalization, UploadFinalization
+from s3_file_field._multipart import MultipartManager, PartCompletion, UploadCompletion
 from s3_file_field._multipart_boto3 import Boto3MultipartManager
 from s3_file_field._multipart_minio import MinioMultipartManager
 
@@ -116,13 +116,13 @@ def test_multipart_manager_initialize_upload(multipart_manager: MultipartManager
 
 
 @pytest.mark.parametrize('file_size', [10, mb(10), mb(12)], ids=['10B', '10MB', '12MB'])
-def test_multipart_manager_finalize_upload(multipart_manager: MultipartManager, file_size: int):
+def test_multipart_manager_complete_upload(multipart_manager: MultipartManager, file_size: int):
     initialization = multipart_manager.initialize_upload(
         'new-object',
         file_size,
     )
 
-    finalization = UploadFinalization(
+    finalization = UploadCompletion(
         object_key=initialization.object_key, upload_id=initialization.upload_id, parts=[]
     )
 
@@ -130,14 +130,12 @@ def test_multipart_manager_finalize_upload(multipart_manager: MultipartManager, 
         resp = requests.put(part.upload_url, data=b'a' * part.size)
         resp.raise_for_status()
         finalization.parts.append(
-            PartFinalization(
-                part_number=part.part_number, size=part.size, etag=resp.headers['ETag']
-            )
+            PartCompletion(part_number=part.part_number, size=part.size, etag=resp.headers['ETag'])
         )
 
-    finalization = multipart_manager.finalize_upload(finalization)
+    finalization = multipart_manager.complete_upload(finalization)
     assert finalization
-    assert finalization.finalize_url
+    assert finalization.complete_url
     assert finalization.body
 
 
@@ -170,22 +168,22 @@ def test_multipart_manager_generate_presigned_part_url_content_length(
     assert 'content-length' in upload_url
 
 
-def test_multipart_manager_generate_presigned_finalize_url(multipart_manager: MultipartManager):
-    upload_url = multipart_manager._generate_presigned_finalize_url(
-        UploadFinalization(object_key='new-object', upload_id='fake-upload-id', parts=[])
+def test_multipart_manager_generate_presigned_complete_url(multipart_manager: MultipartManager):
+    upload_url = multipart_manager._generate_presigned_complete_url(
+        UploadCompletion(object_key='new-object', upload_id='fake-upload-id', parts=[])
     )
 
     assert isinstance(upload_url, str)
 
 
-def test_multipart_manager_marshal_finalize_body(multipart_manager: MultipartManager):
-    body = multipart_manager.marshal_finalize_body(
-        UploadFinalization(
+def test_multipart_manager_marshal_complete_body(multipart_manager: MultipartManager):
+    body = multipart_manager._marshal_complete_body(
+        UploadCompletion(
             object_key='new-object',
             upload_id='fake-upload-id',
             parts=[
-                PartFinalization(part_number=1, size=1, etag='fake-etag-1'),
-                PartFinalization(part_number=2, size=2, etag='fake-etag-2'),
+                PartCompletion(part_number=1, size=1, etag='fake-etag-1'),
+                PartCompletion(part_number=2, size=2, etag='fake-etag-2'),
             ],
         )
     )
@@ -196,6 +194,22 @@ def test_multipart_manager_marshal_finalize_body(multipart_manager: MultipartMan
         '<Part><PartNumber>2</PartNumber><ETag>fake-etag-2</ETag></Part>'
         '</CompleteMultipartUpload>'
     )
+
+
+def test_multipart_manager_get_upload_size(multipart_manager: MultipartManager):
+    # TODO: this abuses the leftover object from test_multipart_manager_complete_upload
+    size = multipart_manager.get_upload_size(
+        object_key='new-object',
+    )
+
+    assert size == 12 * 1024 * 1024
+
+
+def test_multipart_manager_get_upload_size_not_found(multipart_manager: MultipartManager):
+    with pytest.raises(ValueError, match=r'Object not found'):
+        multipart_manager.get_upload_size(
+            object_key='no-such-object',
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -196,13 +196,30 @@ def test_multipart_manager_marshal_complete_body(multipart_manager: MultipartMan
     )
 
 
-def test_multipart_manager_get_upload_size(multipart_manager: MultipartManager):
-    # TODO: this abuses the leftover object from test_multipart_manager_complete_upload
+@pytest.mark.parametrize('file_size', [10, mb(10), mb(12)], ids=['10B', '10MB', '12MB'])
+def test_multipart_manager_get_upload_size(multipart_manager: MultipartManager, file_size: int):
+    # Upload an object
+    initialization = multipart_manager.initialize_upload(
+        'new-object',
+        file_size,
+    )
+    completion = UploadCompletion(
+        object_key=initialization.object_key, upload_id=initialization.upload_id, parts=[]
+    )
+    for part in initialization.parts:
+        resp = requests.put(part.upload_url, data=b'a' * part.size)
+        resp.raise_for_status()
+        completion.parts.append(
+            PartCompletion(part_number=part.part_number, size=part.size, etag=resp.headers['ETag'])
+        )
+    completed_upload = multipart_manager.complete_upload(completion)
+    requests.post(completed_upload.complete_url, data=completed_upload.body)
+
     size = multipart_manager.get_upload_size(
         object_key='new-object',
     )
 
-    assert size == 12 * 1024 * 1024
+    assert size == file_size
 
 
 def test_multipart_manager_get_upload_size_not_found(multipart_manager: MultipartManager):

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -9,7 +9,12 @@ import pytest
 import requests
 from storages.backends.s3boto3 import S3Boto3Storage
 
-from s3_file_field._multipart import MultipartManager, TransferredPart, TransferredParts
+from s3_file_field._multipart import (
+    MultipartManager,
+    ObjectNotFoundException,
+    TransferredPart,
+    TransferredParts,
+)
 from s3_file_field._multipart_boto3 import Boto3MultipartManager
 from s3_file_field._multipart_minio import MinioMultipartManager
 
@@ -224,7 +229,7 @@ def test_multipart_manager_get_object_size(multipart_manager: MultipartManager, 
 
 
 def test_multipart_manager_get_object_size_not_found(multipart_manager: MultipartManager):
-    with pytest.raises(ValueError, match=r'Object not found'):
+    with pytest.raises(ObjectNotFoundException):
         multipart_manager.get_object_size(
             object_key='no-such-object',
         )

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -133,10 +133,10 @@ def test_multipart_manager_complete_upload(multipart_manager: MultipartManager, 
             PartCompletion(part_number=part.part_number, size=part.size, etag=resp.headers['ETag'])
         )
 
-    completion = multipart_manager.complete_upload(completion)
-    assert completion
-    assert completion.complete_url
-    assert completion.body
+    completed_upload = multipart_manager.complete_upload(completion)
+    assert completed_upload
+    assert completed_upload.complete_url
+    assert completed_upload.body
 
 
 def test_multipart_manager_test_upload(multipart_manager: MultipartManager):

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -198,7 +198,7 @@ def test_multipart_manager_generate_presigned_complete_body(multipart_manager: M
 
 
 @pytest.mark.parametrize('file_size', [10, mb(10), mb(12)], ids=['10B', '10MB', '12MB'])
-def test_multipart_manager_get_upload_size(multipart_manager: MultipartManager, file_size: int):
+def test_multipart_manager_get_object_size(multipart_manager: MultipartManager, file_size: int):
     # Upload an object
     initialization = multipart_manager.initialize_upload(
         'new-object',
@@ -216,16 +216,16 @@ def test_multipart_manager_get_upload_size(multipart_manager: MultipartManager, 
     completed_upload = multipart_manager.complete_upload(completion)
     requests.post(completed_upload.complete_url, data=completed_upload.body)
 
-    size = multipart_manager.get_upload_size(
+    size = multipart_manager.get_object_size(
         object_key='new-object',
     )
 
     assert size == file_size
 
 
-def test_multipart_manager_get_upload_size_not_found(multipart_manager: MultipartManager):
+def test_multipart_manager_get_object_size_not_found(multipart_manager: MultipartManager):
     with pytest.raises(ValueError, match=r'Object not found'):
-        multipart_manager.get_upload_size(
+        multipart_manager.get_object_size(
             object_key='no-such-object',
         )
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -122,18 +122,18 @@ def test_multipart_manager_complete_upload(multipart_manager: MultipartManager, 
         file_size,
     )
 
-    finalization = UploadCompletion(
+    completion = UploadCompletion(
         object_key=initialization.object_key, upload_id=initialization.upload_id, parts=[]
     )
 
     for part in initialization.parts:
         resp = requests.put(part.upload_url, data=b'a' * part.size)
         resp.raise_for_status()
-        finalization.parts.append(
+        completion.parts.append(
             PartCompletion(part_number=part.part_number, size=part.size, etag=resp.headers['ETag'])
         )
 
-    finalization = multipart_manager.complete_upload(finalization)
+    finalization = multipart_manager.complete_upload(completion)
     assert finalization
     assert finalization.complete_url
     assert finalization.body

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -189,12 +189,12 @@ def test_multipart_manager_marshal_finalize_body(multipart_manager: MultipartMan
             ],
         )
     )
-    print(body)
+
     assert body == (
-        b'<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
-        b'<Part><PartNumber>1</PartNumber><ETag>"fake-etag-1"</ETag></Part>'
-        b'<Part><PartNumber>2</PartNumber><ETag>"fake-etag-2"</ETag></Part>'
-        b'</CompleteMultipartUpload>'
+        '<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+        '<Part><PartNumber>1</PartNumber><ETag>fake-etag-1</ETag></Part>'
+        '<Part><PartNumber>2</PartNumber><ETag>fake-etag-2</ETag></Part>'
+        '</CompleteMultipartUpload>'
     )
 
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -67,6 +67,6 @@ def test_upload_completion_request_deserialization():
     )
 
     assert serializer.is_valid(raise_exception=True)
-    finalization = serializer.save()
-    assert isinstance(finalization, UploadCompletion)
-    assert all(isinstance(part, PartCompletion) for part in finalization.parts)
+    completion = serializer.save()
+    assert isinstance(completion, UploadCompletion)
+    assert all(isinstance(part, PartCompletion) for part in completion.parts)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -3,11 +3,11 @@ import pytest
 from s3_file_field._multipart import (
     InitializedPart,
     InitializedUpload,
-    PartFinalization,
-    UploadFinalization,
+    PartCompletion,
+    UploadCompletion,
 )
 from s3_file_field.views import (
-    UploadFinalizationRequestSerializer,
+    UploadCompletionRequestSerializer,
     UploadInitializationRequestSerializer,
     UploadInitializationResponseSerializer,
 )
@@ -33,7 +33,7 @@ def initialization() -> InitializedUpload:
     )
 
 
-def test_upload_request_deserialization():
+def test_upload_initialization_request_deserialization():
     serializer = UploadInitializationRequestSerializer(
         data={
             'field_id': 'package.Class.field',
@@ -46,15 +46,15 @@ def test_upload_request_deserialization():
     assert isinstance(request, dict)
 
 
-def test_upload_initialization_serialization(
+def test_upload_initialization_response_serialization(
     initialization: InitializedUpload,
 ):
     serializer = UploadInitializationResponseSerializer(initialization)
     assert isinstance(serializer.data, dict)
 
 
-def test_upload_finalization_deserialization():
-    serializer = UploadFinalizationRequestSerializer(
+def test_upload_completion_request_deserialization():
+    serializer = UploadCompletionRequestSerializer(
         data={
             'field_id': 'package.Class.field',
             'object_key': 'test-object-key',
@@ -68,5 +68,5 @@ def test_upload_finalization_deserialization():
 
     assert serializer.is_valid(raise_exception=True)
     finalization = serializer.save()
-    assert isinstance(finalization, UploadFinalization)
-    assert all(isinstance(part, PartFinalization) for part in finalization.parts)
+    assert isinstance(finalization, UploadCompletion)
+    assert all(isinstance(part, PartCompletion) for part in finalization.parts)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -2,10 +2,10 @@ from django.core import signing
 import pytest
 
 from s3_file_field._multipart import (
-    InitializedPart,
-    InitializedUpload,
-    PartCompletion,
-    UploadCompletion,
+    PresignedPartTransfer,
+    PresignedTransfer,
+    TransferredPart,
+    TransferredParts,
 )
 from s3_file_field.views import (
     UploadCompletionRequestSerializer,
@@ -15,17 +15,17 @@ from s3_file_field.views import (
 
 
 @pytest.fixture
-def initialization() -> InitializedUpload:
-    return InitializedUpload(
+def initialization() -> PresignedTransfer:
+    return PresignedTransfer(
         object_key='test-object-key',
         upload_id='test-upload-id',
         parts=[
-            InitializedPart(
+            PresignedPartTransfer(
                 part_number=1,
                 size=10_000,
                 upload_url='http://minio.test/test-bucket/1',
             ),
-            InitializedPart(
+            PresignedPartTransfer(
                 part_number=2,
                 size=3_500,
                 upload_url='http://minio.test/test-bucket/2',
@@ -48,7 +48,7 @@ def test_upload_initialization_request_deserialization():
 
 
 def test_upload_initialization_response_serialization(
-    initialization: InitializedUpload,
+    initialization: PresignedTransfer,
 ):
     serializer = UploadInitializationResponseSerializer(
         {
@@ -76,5 +76,5 @@ def test_upload_completion_request_deserialization():
 
     assert serializer.is_valid(raise_exception=True)
     completion = serializer.save()
-    assert isinstance(completion, UploadCompletion)
-    assert all(isinstance(part, PartCompletion) for part in completion.parts)
+    assert isinstance(completion, TransferredParts)
+    assert all(isinstance(part, TransferredPart) for part in completion.parts)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -100,7 +100,7 @@ def test_full_upload_flow(api_client: APIClient, file_size: int):
     }
     completion_data = cast(Dict, resp.data)
 
-    # Finalize the upload
+    # Complete the upload
     complete_resp = requests.post(
         completion_data['complete_url'],
         data=completion_data['body'],
@@ -110,6 +110,7 @@ def test_full_upload_flow(api_client: APIClient, file_size: int):
     # Verify the object is present in the store
     assert default_storage.exists(initialization['object_key'])
 
+    # Finalize the upload
     resp = api_client.post(
         reverse('s3_file_field:finalize'),
         {

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,3 +1,5 @@
+from typing import Dict, cast
+
 from django.core.files.storage import default_storage
 from django.urls import reverse
 import pytest
@@ -96,14 +98,14 @@ def test_full_upload_flow(api_client: APIClient, file_size: int):
         'body': Re(r'.*'),
         'finalization': Re(r'.*:.*'),
     }
-    finalization = resp.data['finalization']
+    completion_data = cast(Dict, resp.data)
 
     # Finalize the upload
-    resp = requests.post(
-        resp.data['complete_url'],
-        data=resp.data['body'],
+    complete_resp = requests.post(
+        completion_data['complete_url'],
+        data=completion_data['body'],
     )
-    resp.raise_for_status()
+    complete_resp.raise_for_status()
 
     # Verify the object is present in the store
     assert default_storage.exists(initialization['object_key'])
@@ -111,7 +113,7 @@ def test_full_upload_flow(api_client: APIClient, file_size: int):
     resp = api_client.post(
         reverse('s3_file_field:finalize'),
         {
-            'finalization': finalization,
+            'finalization': completion_data['finalization'],
         },
         format='json',
     )


### PR DESCRIPTION
Finalize requests are now presigned, so now clients must call the provided URL with the provided request body to finalize the object creation.