### PR TITLE
Require Python 3.8

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9]
     services:
       minio:
         image: girder/minio-nonroot:latest

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,7 +1,7 @@
 ## Development Environment
 
 ### Requirements
- * Python 3.7
+ * Python 3.8
  * node
  * AWS CLI (AWS setup)
  * docker + docker-compose (MinIO docker setup)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     author='Kitware, Inc',
     author_email='kitware@kitware.com',
     license='Apache 2.0',
-    python_requires='>=3.7.0',
+    python_requires='>=3.8.0',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',
@@ -53,8 +53,8 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python',
     ],
     packages=find_packages(include=['s3_file_field']),


### PR DESCRIPTION
All other Girder 4 tools require Python 3.8.