### PR TITLE
Upload views explicitly do not use authentication

### DIFF
--- a/example/s3ff_example/settings.py
+++ b/example/s3ff_example/settings.py
@@ -54,11 +54,6 @@ STATIC_URL = '/static/'
 ROOT_URLCONF = 's3ff_example.urls'
 WSGI_APPLICATION = 's3ff_example.wsgi.application'
 
-REST_FRAMEWORK = {
-    # TODO: this works around https://github.com/girder/django-s3-file-field/issues/112
-    'DEFAULT_AUTHENTICATION_CLASSES': [],
-}
-
 if 'AWS_ACCESS_KEY_ID' in os.environ:
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     AWS_S3_REGION_NAME = os.environ.get('AWS_DEFAULT_REGION', 'us-east1')

--- a/s3_file_field/views.py
+++ b/s3_file_field/views.py
@@ -3,7 +3,7 @@ from typing import Dict
 from django.core import signing
 from django.http.response import HttpResponseBase
 from rest_framework import serializers
-from rest_framework.decorators import api_view, parser_classes
+from rest_framework.decorators import api_view, authentication_classes, parser_classes
 from rest_framework.parsers import JSONParser
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -70,9 +70,12 @@ class FinalizationResponseSerializer(serializers.Serializer):
     field_value = serializers.CharField(trim_whitespace=False)
 
 
+@api_view(['POST'])
+# authentication_classes needs to be set to skip SessionAuthentication, which requires a CSRF token
+@authentication_classes([])
+# TODO require user to be logged in to upload
 # @authentication_classes([TokenAuthentication])
 # @permission_classes([IsAuthenticated])
-@api_view(['POST'])
 @parser_classes([JSONParser])
 def upload_initialize(request: Request) -> HttpResponseBase:
     request_serializer = UploadInitializationRequestSerializer(data=request.data)
@@ -112,9 +115,12 @@ def upload_initialize(request: Request) -> HttpResponseBase:
     return Response(response_serializer.data)
 
 
+@api_view(['POST'])
+# authentication_classes needs to be set to skip SessionAuthentication, which requires a CSRF token
+@authentication_classes([])
+# TODO require user to be logged in to upload
 # @authentication_classes([TokenAuthentication])
 # @permission_classes([IsAuthenticated])
-@api_view(['POST'])
 @parser_classes([JSONParser])
 def upload_complete(request: Request) -> HttpResponseBase:
     request_serializer = UploadCompletionRequestSerializer(data=request.data)

--- a/s3_file_field/views.py
+++ b/s3_file_field/views.py
@@ -74,7 +74,6 @@ class FinalizationResponseSerializer(serializers.Serializer):
 # authentication_classes needs to be set to skip SessionAuthentication, which requires a CSRF token
 @authentication_classes([])
 # TODO require user to be logged in to upload
-# @authentication_classes([TokenAuthentication])
 # @permission_classes([IsAuthenticated])
 @parser_classes([JSONParser])
 def upload_initialize(request: Request) -> HttpResponseBase:
@@ -119,7 +118,6 @@ def upload_initialize(request: Request) -> HttpResponseBase:
 # authentication_classes needs to be set to skip SessionAuthentication, which requires a CSRF token
 @authentication_classes([])
 # TODO require user to be logged in to upload
-# @authentication_classes([TokenAuthentication])
 # @permission_classes([IsAuthenticated])
 @parser_classes([JSONParser])
 def upload_complete(request: Request) -> HttpResponseBase:
@@ -154,9 +152,11 @@ def upload_complete(request: Request) -> HttpResponseBase:
     return Response(response_serializer.data)
 
 
-# @authentication_classes([TokenAuthentication])
-# @permission_classes([IsAuthenticated])
 @api_view(['POST'])
+# authentication_classes needs to be set to skip SessionAuthentication, which requires a CSRF token
+@authentication_classes([])
+# TODO require user to be logged in to upload
+# @permission_classes([IsAuthenticated])
 @parser_classes([JSONParser])
 def finalize(request: Request) -> HttpResponseBase:
     request_serializer = FinalizationRequestSerializer(data=request.data)


### PR DESCRIPTION
When `SessionAuthentication` is included as an authentication option, it
requires a CSRF token on all requests, which is not included by the JS
client. Now the upload views explicitly do not use any authentication so
`SessionAuthentication` is never applied.

Fixes #112 