### PR TITLE
Remove non-auto-upload capability from widget

### DIFF
--- a/s3_file_field/forms.py
+++ b/s3_file_field/forms.py
@@ -40,7 +40,6 @@ class S3FormFileField(FileField):
         attrs = super().widget_attrs(widget)
         attrs.update(
             {
-                'data-auto-upload': True,
                 'data-field-id': self.model_field_id,
                 'data-s3fileinput': '',
             }

--- a/widget/src/style.scss
+++ b/widget/src/style.scss
@@ -129,15 +129,7 @@ $dot-width: 0.5em;
   }
 }
 
-.#{$css_prefix}-autoupload {
-  display: none;
-}
-
 .#{$css_prefix}-uploading {
-  .#{$css_prefix}-upload {
-    display: none;
-  }
-
   .#{$css_prefix}-abort {
     display: unset;
   }
@@ -148,9 +140,6 @@ $dot-width: 0.5em;
 }
 
 .#{$css_prefix}-set {
-  .#{$css_prefix}-upload {
-    display: none;
-  }
   .#{$css_prefix}-info {
     display: inline-block;
   }


### PR DESCRIPTION
Auto-upload was always enabled, so the non-auto-upload capability was never used and added to the code maintenance burden.