### PR TITLE
Disable widget sourcemaps

### DIFF
--- a/widget/package.json
+++ b/widget/package.json
@@ -9,7 +9,7 @@
     "lint": "npm-run-all lint:*",
     "watch": "parcel watch ./src/widget.ts --out-dir ../s3_file_field/static/s3_file_field/",
     "build:clean": "rimraf ../s3_file_field/static/s3_file_field",
-    "build:compile": "parcel build ./src/widget.ts --out-dir ../s3_file_field/static/s3_file_field/",
+    "build:compile": "parcel build ./src/widget.ts --out-dir ../s3_file_field/static/s3_file_field/ --no-source-maps",
     "build": "npm-run-all build:*"
   },
   "dependencies": {


### PR DESCRIPTION
These don't work, so it's wasted space to publish them.