### PR TITLE
Extend signature expiration time to 7 days

### DIFF
--- a/s3_file_field/_multipart.py
+++ b/s3_file_field/_multipart.py
@@ -141,7 +141,7 @@ class MultipartManager:
             return True
 
     # The AWS default expiration of 1 hour may not be enough for large uploads to complete
-    _url_expiration = timedelta(hours=24)
+    _url_expiration = timedelta(days=7)
 
     def _create_upload_id(self, object_key: str) -> str:
         raise NotImplementedError


### PR DESCRIPTION
This reduces the probability of users timing out on uploads, and from a theoretical security standpoint, isn't materially worse than 1 day.

Note that 7 days is the maximum amount supported by access key signing in S3.