### PR TITLE
Add python test client

### DIFF
--- a/s3_file_field/testing.py
+++ b/s3_file_field/testing.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import io
+from typing import BinaryIO, Dict, List
+
+import requests
+
+
+@dataclass
+class _File:
+    name: str
+    size: int
+    stream: BinaryIO
+
+    @classmethod
+    def from_stream(cls, stream: BinaryIO, name: str) -> _File:
+        if not stream.seekable():
+            raise Exception('File stream is not seekable.')
+
+        stream.seek(0, io.SEEK_END)
+        size = stream.tell()
+        stream.seek(0, io.SEEK_SET)
+
+        return cls(name=name, size=size, stream=stream)
+
+
+class S3FileFieldTestClient:
+    def __init__(self, api_client, base_url: str):
+        """
+        Initialize a S3FileField test client.
+
+        Args:
+            api_client: An instance of `rest_framework.test.APIClient`.
+            base_url: The relative path that s3_file_field.urls is mounted at.
+        """
+        self.api_client = api_client
+        self.base_url = base_url.rstrip('/')
+
+    def _initialize_upload(self, file: _File, field_id: str) -> Dict:
+        resp = self.api_client.post(
+            f'{self.base_url}/upload-initialize/',
+            {
+                'field_id': field_id,
+                'file_name': file.name,
+                'file_size': file.size,
+            },
+            format='json',
+        )
+
+        assert resp.status_code < 400
+        return resp.json()
+
+    def _upload_part(self, part_bytes: bytes, part_initialization: Dict):
+        resp = requests.put(part_initialization['upload_url'], data=part_bytes)
+        resp.raise_for_status()
+
+        etag = resp.headers['ETag']
+
+        return {
+            'part_number': part_initialization['part_number'],
+            'size': part_initialization['size'],
+            'etag': etag,
+        }
+
+    def _upload_parts(self, file: _File, part_initializations: List[Dict]) -> List[Dict]:
+        return [
+            self._upload_part(file.stream.read(part_initialization['size']), part_initialization)
+            for part_initialization in part_initializations
+        ]
+
+    def _complete_upload(self, multipart_info: Dict, upload_infos: List[Dict]) -> None:
+        resp = self.api_client.post(
+            f'{self.base_url}/upload-complete/',
+            {
+                'upload_id': multipart_info['upload_id'],
+                'parts': upload_infos,
+                'upload_signature': multipart_info['upload_signature'],
+            },
+            format='json',
+        )
+
+        assert resp.status_code < 400
+        completion_data = resp.json()
+
+        complete_resp = requests.post(completion_data['complete_url'], data=completion_data['body'])
+        complete_resp.raise_for_status()
+
+    def _finalize(self, multipart_info: Dict) -> str:
+        resp = self.api_client.post(
+            f'{self.base_url}/finalize/',
+            {
+                'upload_signature': multipart_info['upload_signature'],
+            },
+            format='json',
+        )
+        assert resp.status_code < 400
+        return resp.json()
+
+    def upload_file(self, file_stream: BinaryIO, file_name: str, field_id: str) -> str:
+        file = _File.from_stream(file_stream, file_name)
+        multipart_info = self._initialize_upload(file, field_id)
+        upload_infos = self._upload_parts(file, multipart_info['parts'])
+        self._complete_upload(multipart_info, upload_infos)
+        field_value = self._finalize(multipart_info)
+        return field_value

--- a/s3_file_field/testing.py
+++ b/s3_file_field/testing.py
@@ -86,7 +86,7 @@ class S3FileFieldTestClient:
         complete_resp = requests.post(completion_data['complete_url'], data=completion_data['body'])
         complete_resp.raise_for_status()
 
-    def _finalize(self, multipart_info: Dict) -> str:
+    def _finalize(self, multipart_info: Dict) -> Dict:
         resp = self.api_client.post(
             f'{self.base_url}/finalize/',
             {
@@ -97,7 +97,7 @@ class S3FileFieldTestClient:
         assert resp.status_code < 400
         return resp.json()
 
-    def upload_file(self, file_stream: BinaryIO, file_name: str, field_id: str) -> str:
+    def upload_file(self, file_stream: BinaryIO, file_name: str, field_id: str) -> Dict:
         file = _File.from_stream(file_stream, file_name)
         multipart_info = self._initialize_upload(file, field_id)
         upload_infos = self._upload_parts(file, multipart_info['parts'])

--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -1,0 +1,38 @@
+import io
+import json
+from typing import Dict
+
+from django.core import signing
+import pytest
+
+from s3_file_field.testing import S3FileFieldTestClient
+
+# Create test json file
+test_json_str = json.dumps(
+    {
+        'a': 1,
+        'b': 2,
+        'c': 3,
+        'd': 4,
+    }
+)
+
+
+@pytest.fixture()
+def s3ff_client(api_client):
+    return S3FileFieldTestClient(api_client, '/api/s3ff_test')
+
+
+@pytest.mark.django_db
+def test_field_value(s3ff_client):
+    with io.StringIO(test_json_str) as file_stream:
+        field_value_dict = s3ff_client.upload_file(
+            file_stream, 'test.json', 'test_app.Resource.blob'
+        )
+
+    # Verifies that the response is in a correct format
+    field_value = field_value_dict['field_value']
+    loaded_dict: Dict = signing.loads(field_value)
+
+    assert 'object_key' in loaded_dict
+    assert 'file_size' in loaded_dict


### PR DESCRIPTION
Fixes #226 

This largely replicates the behavior/structure of the existing [python client](https://github.com/girder/django-s3-file-field/blob/master/python-client/s3_file_field_client/__init__.py), but replaces actual requests with requests to a DRF test `APIClient`.

I realize some things between the python client and this module are duplicated (namely the `_File` class), but I didn't want to make assumptions / complicate the codebase just to abstract away that one thing. If this is an issue and there's a better way to approach it please lmk.

I've also modified the behavior of the `upload_file` function to directly return the `field_value`, instead of a dict with the format:

```python
{
    'field_value': field_value,
}
```

It seems to me it's more useful to just return the direct `field_value`. If this is an incorrect assumption I can revert this change.