### PR TITLE
Fix the return value of S3FileFieldClient.upload_file

### DIFF
--- a/python-client/s3_file_field_client/__init__.py
+++ b/python-client/s3_file_field_client/__init__.py
@@ -83,7 +83,7 @@ class S3FileFieldClient:
             },
         )
         resp.raise_for_status()
-        return resp.json()
+        return resp.json()['field_value']
 
     def upload_file(self, file_stream: BinaryIO, file_name: str, field_id: str) -> str:
         file = _File.from_stream(file_stream, file_name)

--- a/s3_file_field/testing.py
+++ b/s3_file_field/testing.py
@@ -86,7 +86,7 @@ class S3FileFieldTestClient:
         complete_resp = requests.post(completion_data['complete_url'], data=completion_data['body'])
         complete_resp.raise_for_status()
 
-    def _finalize(self, multipart_info: Dict) -> Dict:
+    def _finalize(self, multipart_info: Dict) -> str:
         resp = self.api_client.post(
             f'{self.base_url}/finalize/',
             {
@@ -95,9 +95,9 @@ class S3FileFieldTestClient:
             format='json',
         )
         assert resp.status_code < 400
-        return resp.json()
+        return resp.json()['field_value']
 
-    def upload_file(self, file_stream: BinaryIO, file_name: str, field_id: str) -> Dict:
+    def upload_file(self, file_stream: BinaryIO, file_name: str, field_id: str) -> str:
         file = _File.from_stream(file_stream, file_name)
         multipart_info = self._initialize_upload(file, field_id)
         upload_infos = self._upload_parts(file, multipart_info['parts'])

--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -26,12 +26,9 @@ def s3ff_client(api_client):
 @pytest.mark.django_db
 def test_field_value(s3ff_client):
     with io.StringIO(test_json_str) as file_stream:
-        field_value_dict = s3ff_client.upload_file(
-            file_stream, 'test.json', 'test_app.Resource.blob'
-        )
+        field_value = s3ff_client.upload_file(file_stream, 'test.json', 'test_app.Resource.blob')
 
     # Verifies that the response is in a correct format
-    field_value = field_value_dict['field_value']
     loaded_dict: Dict = signing.loads(field_value)
 
     assert 'object_key' in loaded_dict


### PR DESCRIPTION
This matches the behavior of the JS client and the design intent.

Found by @jbeezley in #228.