### PR TITLE
Validate client-provided field ID

### DIFF
--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,5 +1,6 @@
 from django.core import signing
 import pytest
+from rest_framework.exceptions import ValidationError
 
 from s3_file_field._multipart import (
     PresignedPartTransfer,
@@ -45,6 +46,19 @@ def test_upload_initialization_request_deserialization():
     assert serializer.is_valid(raise_exception=True)
     request = serializer.validated_data
     assert isinstance(request, dict)
+
+
+def test_upload_initialization_request_deserialization_file_id_invalid():
+    serializer = UploadInitializationRequestSerializer(
+        data={
+            'field_id': 'bad.id',
+            'file_name': 'test-name.jpg',
+            'file_size': 15,
+        }
+    )
+    with pytest.raises(ValidationError) as e:
+        serializer.is_valid(raise_exception=True)
+    assert e.value.detail == {'field_id': ['Invalid field ID: "bad.id".']}
 
 
 def test_upload_initialization_response_serialization(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -31,16 +31,6 @@ def test_prepare(api_client):
     }
 
 
-def test_initialize_file_id_invalid(api_client):
-    resp = api_client.post(
-        reverse('s3_file_field:upload-initialize'),
-        {'field_id': 'bad.id', 'file_name': 'test.txt', 'file_size': mb(12)},
-        format='json',
-    )
-    assert resp.status_code == 400
-    assert resp.json() == {'field_id': ['Invalid field ID: "bad.id".']}
-
-
 def test_prepare_two_parts(api_client):
     resp = api_client.post(
         reverse('s3_file_field:upload-initialize'),


### PR DESCRIPTION
Prior to this change, passing an invalid field_id to the initialization endpoint would cause an unhandled KeyError yielding a 500 response.