### PR TITLE
Satisfy mypy

### DIFF
--- a/s3_file_field/_registry.py
+++ b/s3_file_field/_registry.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Iterator, cast
 from weakref import WeakValueDictionary
 
 from django.core.files.storage import Storage
@@ -22,7 +22,7 @@ def register_field(field: 'S3FileField') -> None:
         raise Exception(f'Cannot overwrite existing S3FileField declaration for {field_id}')
     _fields[field_id] = field
 
-    storage = field.storage
+    storage = cast(Storage, field.storage)
     storage_label = id(storage)
     _storages[storage_label] = storage
 

--- a/s3_file_field/fields.py
+++ b/s3_file_field/fields.py
@@ -1,9 +1,10 @@
 import logging
-from typing import Any, List
+from typing import Any, List, cast
 from uuid import uuid4
 
 from django.core import checks
 from django.core.checks import CheckMessage
+from django.core.files.storage import Storage
 from django.db import models
 from django.db.models.fields.files import FileField
 from django.forms import Field as FormField
@@ -69,7 +70,7 @@ class S3FileField(FileField):
 
         This is an instance of "form_class", with a widget of "widget".
         """
-        if MultipartManager.supported_storage(self.storage):
+        if MultipartManager.supported_storage(cast(Storage, self.storage)):
             # Use S3FormFileField as a default, instead of forms.FileField from the superclass
             kwargs.setdefault('form_class', S3FormFileField)
             # Allow the form and widget to lookup this field instance later, using its id
@@ -95,7 +96,7 @@ class S3FileField(FileField):
         ]
 
     def _check_supported_storage_provider(self) -> List[checks.CheckMessage]:
-        if not MultipartManager.supported_storage(self.storage):
+        if not MultipartManager.supported_storage(cast(Storage, self.storage)):
             msg = f'Incompatible storage type used with an {self.__class__.__name__}.'
             logger.warning(msg)
             return [checks.Warning(msg, obj=self, id='s3_file_field.W001')]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def resource() -> Resource:
 def stored_file_object() -> Generator[File, None, None]:
     """Return a File object, already saved directly into Storage."""
     # Ensure the name is always randomized, even if the key doesn't exist already
-    key = default_storage.get_alternative_name('test_key', '')
+    key = default_storage.get_alternative_name('test_key', '')  # type: ignore[attr-defined]
     # In theory, Storage.save can change the key, though this shouldn't happen with a randomized key
     key = default_storage.save(key, ContentFile(b'test content'))
     # Storage.open will return a File object, which knows its size and can access its content


### PR DESCRIPTION
I'm not sure how long CI has been broken, but this is a potential fix.

A running theme here is that statically, it looks like the `storage` attribute of a `FileField` could be a `Callable`, but by the time we reference it, it should have already been resolved to a `Storage`.