### PR TITLE
Remove support for Django 4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',
         'Framework :: Django :: 3.2',
-        'Framework :: Django :: 4.0',
         'Framework :: Django',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     lint,
     type,
-    test-django{32,40,41}
+    test-django{32,41}
 
 [testenv]
 extras =
@@ -45,7 +45,7 @@ commands =
     isort {posargs:.}
     black {posargs:.}
 
-[testenv:test-django{32,40,41}]
+[testenv:test-django{32,41}]
 passenv =
     MINIO_STORAGE_ENDPOINT
     MINIO_STORAGE_ACCESS_KEY
@@ -53,7 +53,6 @@ passenv =
     MINIO_STORAGE_MEDIA_BUCKET_NAME
 deps =
     django32: Django==3.2.*
-    django40: Django==4.0.*
     django41: Django==4.1.*
     factory-boy
     pytest


### PR DESCRIPTION
Django 4.0 is EOL: https://www.djangoproject.com/download/#supported-versions