### PR TITLE
Simplify Docker Compose config, removing port customization option

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     image: minio/minio:latest
     # When run with a TTY, minio prints credentials on startup
     tty: true
-    command: ["server", "/data", "--console-address", ":${DOCKER_MINIO_CONSOLE_PORT-9001}"]
+    command: ["server", "/data", "--console-address", ":9001"]
     environment:
       MINIO_ROOT_USER: minioAccessKey
       MINIO_ROOT_PASSWORD: minioSecretKey
     ports:
-      - ${DOCKER_MINIO_PORT-9000}:9000
-      - ${DOCKER_MINIO_CONSOLE_PORT-9001}:9001
+      - "9000:9000"
+      - "9001:9001"


### PR DESCRIPTION
This is not well-integrated with the rest of the example app.