### PR TITLE
Fix a test failure due to Django warnings

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -62,6 +62,9 @@ def test_registry_iter_storages() -> None:
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="Bug bpo-35113")
+@pytest.mark.filterwarnings(
+    "ignore:Model 'test_app\\.ephemeralresource' was already registered:RuntimeWarning"
+)
 def test_registry_register_field_multiple(ephemeral_s3ff_field: S3FileField) -> None:
     with pytest.warns(
         RuntimeWarning, match=r"Overwriting existing S3FileField declaration"


### PR DESCRIPTION
This was caused by a change in pytest 8:
> [#9288](https://github.com/pytest-dev/pytest/issues/9288): [warns()](https://docs.pytest.org/en/latest/reference/reference.html#pytest.warns) now re-emits unmatched warnings when the context closes – previously it would consume all warnings, hiding those that were not matched by the function.
> 
> While this is a new feature, we announce it as a breaking change because many test suites are configured to error-out on warnings, and will therefore fail on the newly-re-emitted warnings.