### PR TITLE
Fix issue caused by Django 5.1 added FileField name validation

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -5,6 +5,7 @@ from django.core.files.base import ContentFile
 import pytest
 
 from test_app.models import Resource
+from s3_file_field.widgets import S3PlaceholderFile
 
 
 @pytest.mark.django_db()
@@ -62,3 +63,22 @@ def test_fields_clean_empty() -> None:
 
 def test_fields_check_success(resource: Resource) -> None:
     assert resource._meta.get_field("blob").check() == []
+
+
+def test_s3_placeholder_file_save_form_data() -> None:
+    resource = Resource()
+    blob_field = resource._meta.get_field("blob")
+    placeholder_file = S3PlaceholderFile(name="test-file.txt")
+    blob_field.save_form_data(resource, placeholder_file)
+    assert getattr(resource, blob_field.attname) == "test-file.txt"
+
+
+@pytest.mark.django_db()
+def test_s3_placeholder_file_save_form_data_with_save() -> None:
+    resource = Resource()
+    blob_field = resource._meta.get_field("blob")
+    placeholder_file = S3PlaceholderFile(name="test-file-save.txt")
+    blob_field.save_form_data(resource, placeholder_file)
+    resource.save()
+    resource.refresh_from_db()
+    assert resource.blob.name == "test-file-save.txt"


### PR DESCRIPTION
### Problem
Django 5.1 introduced a breaking change in FileField.pre_save() that raises a FieldError when trying to save a file without a name attribute:
https://docs.djangoproject.com/en/5.2/releases/5.1/#miscellaneous

This caused S3FileField to fail with the error "str has no attribute .name" because the existing save_form_data method converts S3PlaceholderFile objects to strings before passing them to the parent class.

### Solution
Modified save_form_data to handle S3PlaceholderFile objects by directly setting the field attribute using setattr, bypassing Django's FileField validation while maintaining the same behaviour of storing the filename as a string in the database.